### PR TITLE
Remove finally and move writer to try statement

### DIFF
--- a/standalone-examples/src/main/java/com/emc/pravega/example/gettingstarted/hello/HelloWorldWriter.java
+++ b/standalone-examples/src/main/java/com/emc/pravega/example/gettingstarted/hello/HelloWorldWriter.java
@@ -35,21 +35,20 @@ public class HelloWorldWriter {
     }
 
     public void run(String routingKey, String message) {
+        StreamManager streamManager = StreamManager.create(controllerURI);
+        streamManager.createScope(scope);
 
-        try ( ClientFactory clientFactory = ClientFactory.withScope(scope, controllerURI);
-              StreamManager streamManager = StreamManager.create(controllerURI);
-              EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
-                                                                                 new JavaSerializer<String>(),
-                                                                                 EventWriterConfig.builder().build())) {
-            
-            streamManager.createScope(scope);
-
-            StreamConfiguration streamConfig = StreamConfiguration.builder().scope(scope).streamName(streamName)
+        StreamConfiguration streamConfig = StreamConfiguration.builder().scope(scope).streamName(streamName)
                 .scalingPolicy(ScalingPolicy.fixed(1))
                 .build();
 
-            streamManager.createStream(scope, streamName, streamConfig);
+        streamManager.createStream(scope, streamName, streamConfig);
 
+        try (ClientFactory clientFactory = ClientFactory.withScope(scope, controllerURI);
+             EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
+                                                                                 new JavaSerializer<String>(),
+                                                                                 EventWriterConfig.builder().build())) {
+            
             System.out.format("******** Writing message: '%s' with routing-key: '%s' to stream '%s / %s'%n",
                     message, routingKey, scope, streamName);
             writer.writeEvent(routingKey, message);


### PR DESCRIPTION
The current writer sample has a race because the `ClientFactory` is auto-closed and the writer depends on its resources.

This pull request moves the writer creation to the try statement and removes the finally block.