### PR TITLE
Issue 1099: Updated for Maven Central Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,22 @@
 Sample applications for Pravega.
 
 ## Getting Started
+
 ### Building Pravega
+
+Optional: This step is required only if you want to use a different version
+of Pravega than is published to maven central.
 
 Install the Pravega client libraries to your local Maven repository:
 ```
 $ git clone https://github.com/pravega/pravega.git
-$./gradlew publishMavenPublicationToMavenLocal
+$./gradlew install
 ```
 
 ### Building the Flink Connector
+
+Optional: This step is required only if you want to use a different version
+of Pravega than is published to maven central.
 
 Install the shaded Flink Connector library to your local Maven repository:
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,9 @@ subprojects {
         maven {
             url "https://repository.apache.org/snapshots"
         }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots"
+        }
     }
     
     plugins.withType(org.gradle.api.plugins.JavaPlugin) {


### PR DESCRIPTION
Added maven snapshots repo. This PR adds this support. We have a test snapshot version up there now. https://github.com/pravega/pravega/pull/1202

Also updated the readme making the build of pravega/flink-connector optional (only if you need a custom version). Also change to use new gradlew command for installing locally.