### PR TITLE
Issue 34 Changed default pravega controller URI to use localhost

### DIFF
--- a/flink-examples/src/main/scala/io/pravega/examples/flink/util/PravegaParameters.scala
+++ b/flink-examples/src/main/scala/io/pravega/examples/flink/util/PravegaParameters.scala
@@ -11,6 +11,6 @@
 package io.pravega.examples.flink.util
 
 object PravegaParameters {
-  val DEFAULT_CONTROLLER_URI = "tcp://controller-pravega.marathon.mesos:9091"
+  val DEFAULT_CONTROLLER_URI = "tcp://127.0.0.1:9090"
 }
 


### PR DESCRIPTION
Closes #34 
Updated only the default URI since the code has already got parameterized option to accept other values

```
$ bin/run-example.sh [--controller <URI>] [--scope <name>] [--stream <name>]
                     [--startTime <long>] [--output <path>]
``` 