### PR TITLE
Changed the name of the flink job

### DIFF
--- a/flink-examples/src/main/scala/io/pravega/examples/flink/iot/TurbineHeatProcessor.scala
+++ b/flink-examples/src/main/scala/io/pravega/examples/flink/iot/TurbineHeatProcessor.scala
@@ -86,7 +86,7 @@ object TurbineHeatProcessor {
       params.scope,
       Set(params.stream),
       params.startTime,
-      new PravegaDeserializationSchema(classOf[String], new JavaSerializer[String]()))).map { line =>
+      new PravegaDeserializationSchema(classOf[String], new JavaSerializer[String]()))).name("stream").map { line =>
       val l = line.trim.split(", ")
       SensorEvent(l(0).toLong, l(1).toInt, l(2), l(3).toFloat)
     }.name("events")
@@ -110,7 +110,7 @@ object TurbineHeatProcessor {
       summaries.writeAsCsv(path, FileSystem.WriteMode.OVERWRITE)
     }
 
-    env.execute(s"Turbine Heat Processor (${params.scope}, ${params.stream})")
+    env.execute(s"TurbineHeatProcessor_${params.scope}_${params.stream}")
   }
 
   /**


### PR DESCRIPTION
Changed the name of the flink job. This job name gets emitted in metrics raw and causes data not to appear in statsd. This is probably a flink bug but we want to be compatible with the current flink release.

Added name for pravega source.