### PR TITLE
Issue 54: Remove unnecessary repository 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,14 +29,13 @@ subprojects {
         jcenter()
         mavenCentral()
         maven {
+            url "https://oss.sonatype.org/content/repositories/iopravega-1008"
+        }
+        maven {
             url "https://repository.apache.org/snapshots"
         }
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots"
-        }
-        //TODO temporarily enabled staging repository to pull Flink 1.4.0-RC3 since it is not published yet to maven central
-        maven {
-            url "https://repository.apache.org/content/repositories/orgapacheflink-1141/"
         }
     }
     

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,6 @@ subprojects {
         jcenter()
         mavenCentral()
         maven {
-            url "https://oss.sonatype.org/content/repositories/iopravega-1008"
-        }
-        maven {
             url "https://repository.apache.org/snapshots"
         }
         maven {


### PR DESCRIPTION
Removes a repository listed in the `repositories` section of `build.gradle` that is no longer needed.

Fixes #54 