### PR TITLE
[issue 75] hadoop-connectors examples

### DIFF
--- a/hadoop-examples/README.md
+++ b/hadoop-examples/README.md
@@ -1,4 +1,14 @@
-# hadoop-connectors examples (Under Development)
+<!--
+Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# hadoop-connectors examples
 Examples of Hadoop Connectors for Pravega.
 
 Description

--- a/hadoop-examples/README.md
+++ b/hadoop-examples/README.md
@@ -13,7 +13,7 @@ Examples of Hadoop Connectors for Pravega.
 
 Description
 -----------
-These examples give you some basic ideas how to use hadoop-connectors for pravega
+These examples give you some basic ideas how to use hadoop-connectors for pravega.
 
 Build
 -------
@@ -45,13 +45,13 @@ Hadoop (verified with Hadoop 2.8.3 on Ubuntu 16.04)
 1. setup and start hdfs
 
 2. set env variables
-   export HDFS=hdfs://192.168.0.188:9000
-   export HADOOP_EXAMPLES_JAR=build/libs/pravega-hadoop-examples-0.3.0-SNAPSHOT-all.jar
+   export HDFS=hdfs://<hdfs_ip_and_port> # e.g. hdfs://192.168.0.188:9000
+   export HADOOP_EXAMPLES_JAR=<pravega-hadoop-examples-0.3.0-SNAPSHOT-all.jar location> # e.g. ./build/libs/pravega-hadoop-examples-0.3.0-SNAPSHOT-all.jar
    export HADOOP_EXAMPLES_INPUT_DUMMY=${HDFS}/tmp/hadoop_examples_input_dummy
    export HADOOP_EXAMPLES_OUTPUT=${HDFS}/tmp/hadoop_examples_output
-   export PRAVEGA_URI=tcp://192.168.0.188:9090
-   export PRAVEGA_SCOPE=myScope
-   export PRAVEGA_STREAM=myStream
+   export PRAVEGA_URI=tcp://<pravega_controller_ip_and_port> # e.g. tcp://192.168.0.188:9090
+   export PRAVEGA_SCOPE=<scope_name>   # e.g. myScope
+   export PRAVEGA_STREAM=<stream_name> # e.g. myStream
    export CMD=wordcount # so far, can also try wordmean and wordmedian
 
 3. make sure below dirs are empty
@@ -69,11 +69,11 @@ Hadoop (verified with Hadoop 2.8.3 on Ubuntu 16.04)
 Additionally, you can run WordCount program (more will be coming soon) on top of [HiBench](https://github.com/intel-hadoop/HiBench)
 ```
 0. set same env variables as previous section, and
-   export HADOOP_HOME=~/services/hadoop-2.8.3
-   export HDFS=hdfs://192.168.0.188:9000
+   export HADOOP_HOME=<hadoop_home_dir>  # e.g. /services/hadoop-2.8.3
+   export HDFS=hdfs://<hdfs_ip_and_port> # e.g. hdfs://192.168.0.188:9000
    export INPUT_HDFS="${HADOOP_EXAMPLES_INPUT_DUMMY} ${PRAVEGA_URI} ${PRAVEGA_SCOPE} ${PRAVEGA_STREAM}"
 
-1. fetch/build/patch HiBench
+1. fetch/build/patch HiBench (make sure mvn is installed)
    gradle wcHiBench
 
 2. prepare testing data

--- a/hadoop-examples/README.md
+++ b/hadoop-examples/README.md
@@ -1,0 +1,84 @@
+# hadoop-connectors examples (Under Development)
+Examples of Hadoop Connectors for Pravega.
+
+Description
+-----------
+These examples give you some basic ideas how to use hadoop-connectors for pravega
+
+Build
+-------
+(Most of these steps will be removed when GAed)
+### build hadoop connectors
+```
+git clone --recurse-submodules https://github.com/pravega/hadoop-connectors.git
+cd hadoop-connectors
+gradle install
+
+# start pravega whose version matches hadoop-connectors
+cd pravega
+./gradlew startStandalone
+```
+
+## build hadoop connectors examples
+```
+open another terminal and goto ~/pravega-samples
+cd hadoop-examples
+gradle build
+```
+
+Run Examples on Local Machine
+---
+
+
+Hadoop (verified with Hadoop 2.8.3 on Ubuntu 16.04)
+```
+1. setup and start hdfs
+
+2. set env variables
+   export HDFS=hdfs://192.168.0.188:9000
+   export HADOOP_EXAMPLES_JAR=build/libs/pravega-hadoop-examples-0.3.0-SNAPSHOT-all.jar
+   export HADOOP_EXAMPLES_INPUT_DUMMY=${HDFS}/tmp/hadoop_examples_input_dummy
+   export HADOOP_EXAMPLES_OUTPUT=${HDFS}/tmp/hadoop_examples_output
+   export PRAVEGA_URI=tcp://192.168.0.188:9090
+   export PRAVEGA_SCOPE=myScope
+   export PRAVEGA_STREAM=myStream
+   export CMD=wordcount # so far, can also try wordmean and wordmedian
+
+3. make sure below dirs are empty
+   hadoop fs -rmr ${HADOOP_EXAMPLES_INPUT_DUMMY}
+   hadoop fs -rmr ${HADOOP_EXAMPLES_OUTPUT}
+
+4. generate words into pravega
+   hadoop jar ${HADOOP_EXAMPLES_JAR} randomtextwriter -D mapreduce.randomtextwriter.totalbytes=32000 ${HADOOP_EXAMPLES_INPUT_DUMMY} ${PRAVEGA_URI} ${PRAVEGA_SCOPE} ${PRAVEGA_STREAM}
+
+5. run hadoop command
+   hadoop jar ${HADOOP_EXAMPLES_JAR} ${CMD} ${HADOOP_EXAMPLES_INPUT_DUMMY} ${PRAVEGA_URI} ${PRAVEGA_SCOPE} ${PRAVEGA_STREAM} ${HADOOP_EXAMPLES_OUTPUT}
+```
+
+
+Additionally, you can run WordCount program (more will be coming soon) on top of [HiBench](https://github.com/intel-hadoop/HiBench)
+```
+0. set same env variables as previous section, and
+   export HADOOP_HOME=~/services/hadoop-2.8.3
+   export HDFS=hdfs://192.168.0.188:9000
+   export INPUT_HDFS="${HADOOP_EXAMPLES_INPUT_DUMMY} ${PRAVEGA_URI} ${PRAVEGA_SCOPE} ${PRAVEGA_STREAM}"
+
+1. fetch/build/patch HiBench
+   gradle wcHiBench
+
+2. prepare testing data
+   ./HiBench/bin/workloads/micro/wordcount/prepare/prepare.sh
+
+3. run
+   ./HiBench/bin/workloads/micro/wordcount/hadoop/run.sh
+
+4. check report
+   file:///<full_path_of_pravega-samples>/hadoop-examples/HiBench/report/wordcount/hadoop/monitor.html
+```
+
+
+You can also use hadoop-connectors on Spark
+```
+Spark (verified with Spark 2.2.1 on Ubuntu 16.04)
+   spark-submit --class io.pravega.examples.spark.WordCount ${HADOOP_EXAMPLES_JAR} ${PRAVEGA_URI} ${PRAVEGA_SCOPE} ${PRAVEGA_STREAM}
+```

--- a/hadoop-examples/build.gradle
+++ b/hadoop-examples/build.gradle
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+plugins {
+    id 'com.github.johnrengelman.shadow' version '1.2.4'
+}
+
+apply plugin: "java"
+apply plugin: "distribution"
+
+sourceCompatibility = 1.8
+archivesBaseName = 'pravega-hadoop-examples'
+version = connectorVersion
+
+repositories {
+    mavenLocal()
+    if (findProperty("repositoryUrl")) {
+        maven {
+            url findProperty("repositoryUrl")
+        }
+    }
+    else {
+        jcenter()
+        mavenCentral()
+        maven { url "https://repository.apache.org/snapshots" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    }
+}
+
+dependencies {
+    compile     "io.pravega:hadoop-connectors:${connectorVersion}"
+    compileOnly "org.apache.hadoop:hadoop-common:${hadoopVersion}"
+    compileOnly "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"
+    compileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
+}
+
+shadowJar {
+    version = version
+    dependencies {
+        include dependency("io.pravega:hadoop-connectors")
+    }
+    manifest {
+        attributes(
+            'Main-Class': 'io.pravega.examples.hadoop.ExampleDriver',
+        )
+    }
+}
+
+distributions {
+    main {
+        baseName = archivesBaseName
+        contents {
+            into('lib') {
+                from shadowJar
+                from(project.configurations.shadow)
+            }
+        }
+    }
+}
+
+task cleanHiBench(type: Delete) {
+    delete 'HiBench'
+}
+
+task fetchHiBench (type: Exec) {
+    commandLine "git", "clone", "https://github.com/intel-hadoop/HiBench"
+}
+
+task buildHiBench (dependsOn: fetchHiBench, type: Exec) {
+    workingDir 'HiBench'
+    commandLine "mvn", "-Dspark=2.1", "-Dscala=2.11", "clean", "package"
+}
+
+task genHiBenchConfig (dependsOn: buildHiBench, type: Copy) {
+    from 'HiBench/conf'
+    into 'HiBench/conf'
+    include 'hadoop.conf.template'
+    rename('hadoop.conf.template', 'hadoop.conf')
+
+    doLast {
+        def file = new File('./HiBench/conf/hadoop.conf')
+        def newConfig = file.text
+            .replace('/PATH/TO/YOUR/HADOOP/ROOT', System.getenv("HADOOP_HOME"))
+            .replace('hdfs://localhost:8020', System.getenv("HDFS"))
+        file.text = newConfig
+    }
+}
+
+task wcHiBench (dependsOn: genHiBenchConfig) {
+    doLast {
+        def file = new File('./HiBench/conf/workloads/micro/wordcount.conf')
+        def newConfig = file.text.replace('hibench.workload.input', '#hibench.workload.input')
+        file.text = newConfig
+    }
+}

--- a/hadoop-examples/gradle.properties
+++ b/hadoop-examples/gradle.properties
@@ -1,0 +1,7 @@
+#
+#  Copyright (c) 2018 Dell Inc., or its subsidiaries.
+#
+hadoopVersion=2.8.1
+scalaVersion=2.11.8
+sparkVersion=2.2.0
+connectorVersion=0.3.0-SNAPSHOT

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/ExampleDriver.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/ExampleDriver.java
@@ -1,21 +1,11 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * Modified by Dell Inc. 2018 by removing unnecessary classes
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.examples.hadoop;
@@ -23,6 +13,9 @@ package io.pravega.examples.hadoop;
 import org.apache.hadoop.util.ProgramDriver;
 
 /**
+ * This class is copied from apache/hadoop and modified by removing
+ * unsupported commands
+ *
  * A description of an example program based on its class and a
  * human-readable description.
  */

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/ExampleDriver.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/ExampleDriver.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modified by Dell Inc. 2018 by removing unnecessary classes
+ */
+
+package io.pravega.examples.hadoop;
+
+import org.apache.hadoop.util.ProgramDriver;
+
+/**
+ * A description of an example program based on its class and a
+ * human-readable description.
+ */
+public class ExampleDriver {
+
+    public static void main(String argv[]) {
+        int exitCode = -1;
+        ProgramDriver pgd = new ProgramDriver();
+        try {
+            pgd.addClass("wordcount", WordCount.class,
+                    "A map/reduce program that counts the words in pravega.");
+            pgd.addClass("wordmean", WordMean.class,
+                    "A map/reduce program that counts the average length of the words in pravega.");
+            pgd.addClass("wordmedian", WordMedian.class,
+                    "A map/reduce program that counts the median length of the words in pravega.");
+            pgd.addClass("randomwriter", RandomWriter.class,
+                    "A map/reduce program that writes random data to pravega.");
+            pgd.addClass("randomtextwriter", RandomTextWriter.class,
+                    "A map/reduce program that writes random textual data to pravega.");
+            exitCode = pgd.run(argv);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
+        System.exit(exitCode);
+    }
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/ExampleDriver.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/ExampleDriver.java
@@ -16,6 +16,9 @@ import org.apache.hadoop.util.ProgramDriver;
  * This class is copied from apache/hadoop and modified by removing
  * unsupported commands
  *
+ * https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-examples
+ * /src/main/java/org/apache/hadoop/examples/ExampleDriver.java
+ *
  * A description of an example program based on its class and a
  * human-readable description.
  */

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputFormat.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputFormat.java
@@ -1,10 +1,11 @@
 /**
  * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.examples.hadoop;

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputFormat.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputFormat.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.examples.hadoop;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.pravega.client.ClientFactory;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.StreamConfiguration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An OutputFormat that can be added as a storage to write events to Pravega.
+ */
+public class PravegaOutputFormat<V> extends OutputFormat<String, V> {
+
+    private static final Logger log = LoggerFactory.getLogger(PravegaOutputFormat.class);
+
+    // Pravega scope name
+    public static final String SCOPE_NAME = "pravega.scope";
+    // Pravega stream name
+    public static final String STREAM_NAME = "pravega.stream";
+    // Pravega uri string
+    public static final String URI_STRING = "pravega.uri";
+    // Pravega deserializer class name
+    public static final String DESERIALIZER = "pravega.deserializer";
+
+    private static final long DEFAULT_TXN_TIMEOUT_MS = 30000L;
+    private static final long DEFAULT_TXN_MAX_EXECUTION_TIME_MS = 30000L;
+    private static final long DEFAULT_TXN_SCALE_GRACE_PERIOD_MS = 30000L;
+    private static final long DEFAULT_PING_LEASE_MS = 30000L;
+
+    // client factory
+    private ClientFactory externalClientFactory;
+
+    public PravegaOutputFormat() {
+    }
+
+    @VisibleForTesting
+    protected PravegaOutputFormat(ClientFactory externalClientFactory) {
+        this.externalClientFactory = externalClientFactory;
+    }
+
+    @Override
+    public RecordWriter<String, V> getRecordWriter(TaskAttemptContext context) throws IOException, InterruptedException {
+        Configuration conf = context.getConfiguration();
+        final String scopeName = Optional.ofNullable(conf.get(PravegaOutputFormat.SCOPE_NAME)).orElseThrow(() ->
+                new IOException("The input scope name must be configured (" + PravegaOutputFormat.SCOPE_NAME + ")"));
+        final String streamName = Optional.ofNullable(conf.get(PravegaOutputFormat.STREAM_NAME)).orElseThrow(() ->
+                new IOException("The input stream name must be configured (" + PravegaOutputFormat.STREAM_NAME + ")"));
+        final URI controllerURI = Optional.ofNullable(conf.get(PravegaOutputFormat.URI_STRING)).map(URI::create).orElseThrow(() ->
+                new IOException("The Pravega controller URI must be configured (" + PravegaOutputFormat.URI_STRING + ")"));
+        final String deserializerClassName = Optional.ofNullable(conf.get(PravegaOutputFormat.DESERIALIZER)).orElseThrow(() ->
+                new IOException("The event deserializer must be configured (" + PravegaOutputFormat.DESERIALIZER + ")"));
+
+        StreamManager streamManager = StreamManager.create(controllerURI);
+        streamManager.createScope(scopeName);
+
+        StreamConfiguration streamConfig = StreamConfiguration.builder().scope(scopeName).streamName(streamName)
+                .scalingPolicy(ScalingPolicy.fixed(3))
+                .build();
+
+        streamManager.createStream(scopeName, streamName, streamConfig);
+        ClientFactory clientFactory = (externalClientFactory != null) ? externalClientFactory : ClientFactory.withScope(scopeName, controllerURI);
+
+        Serializer deserializer;
+        try {
+            Class<?> deserializerClass = Class.forName(deserializerClassName);
+            deserializer = (Serializer<V>) deserializerClass.newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            log.error("Exception when creating deserializer: {}", e);
+            throw new IOException(
+                    "Unable to create the event deserializer (" + deserializerClassName + ")", e);
+        }
+
+        EventStreamWriter<V> writer = clientFactory.createEventWriter(streamName, deserializer, EventWriterConfig.builder()
+                .transactionTimeoutTime(DEFAULT_TXN_TIMEOUT_MS)
+                .transactionTimeoutScaleGracePeriod(DEFAULT_TXN_SCALE_GRACE_PERIOD_MS)
+                .build());
+
+        return new PravegaOutputRecordWriter<V>(writer);
+    }
+
+    @Override
+    public void checkOutputSpecs(JobContext jobContext) throws IOException, InterruptedException {
+    }
+
+    @Override
+    public OutputCommitter getOutputCommitter(TaskAttemptContext context) throws IOException, InterruptedException {
+        // tmp solution, not for production
+        return new FileOutputCommitter(new Path("/tmp/" + context.getTaskAttemptID().getJobID().toString()), context);
+    }
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputRecordWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputRecordWriter.java
@@ -42,7 +42,7 @@ public class PravegaOutputRecordWriter<V> extends RecordWriter<String, V> {
                 if (e != null) {
                     log.warn("Detected a write failure: {}", e);
                 }
-			}
+            }
         );
     }
 

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputRecordWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputRecordWriter.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.examples.hadoop;
+
+import io.pravega.client.stream.EventStreamWriter;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A RecordWriter that can write events to Pravega.
+ */
+@NotThreadSafe
+public class PravegaOutputRecordWriter<V> extends RecordWriter<String, V> {
+
+    private static final Logger log = LoggerFactory.getLogger(PravegaOutputRecordWriter.class);
+    private final EventStreamWriter writer;
+
+    public PravegaOutputRecordWriter(EventStreamWriter writer) {
+        this.writer = writer;
+    }
+
+    @Override
+    public void write(String key, V value) throws IOException, InterruptedException {
+        final CompletableFuture<Void> future = writer.writeEvent(key, value);
+        future.whenCompleteAsync(
+            (v, e) -> {
+                if (e != null) {
+                    log.warn("Detected a write failure: {}", e);
+                }
+			}
+        );
+    }
+
+    @Override
+    public void close(TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+        writer.close();
+    }
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputRecordWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/PravegaOutputRecordWriter.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.examples.hadoop;

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomTextWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomTextWriter.java
@@ -1,21 +1,11 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.examples.hadoop;
@@ -36,6 +26,9 @@ import java.util.Date;
 import java.util.Random;
 
 /**
+ * This class is copied from apache/hadoop and modified by adding logic to
+ * support PravegaInputFormat
+ *
  * This program uses map/reduce to just run a distributed job where there is
  * no interaction between the tasks and each task writes a large unsorted
  * random sequence of words.
@@ -66,10 +59,10 @@ import java.util.Random;
  *     <value>1099511627776</value>
  *   </property>
  * </configuration>}</pre>
- * <p>
+ *
  * Equivalently, {@link RandomTextWriter} also supports all the above options
  * and ones supported by {@link Tool} via the command-line.
- * <p>
+ *
  * To run: bin/hadoop jar hadoop-${version}-examples.jar randomtextwriter
  * [-outFormat <i>output format class</i>] <i>output</i>
  */

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomTextWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomTextWriter.java
@@ -1,0 +1,743 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ */
+
+package io.pravega.examples.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.ClusterStatus;
+import org.apache.hadoop.mapred.JobClient;
+import org.apache.hadoop.mapreduce.*;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Random;
+
+/**
+ * This program uses map/reduce to just run a distributed job where there is
+ * no interaction between the tasks and each task writes a large unsorted
+ * random sequence of words.
+ * In order for this program to generate data for terasort with a 5-10 words
+ * per key and 20-100 words per value, have the following config:
+ * <pre>{@code
+ * <?xml version="1.0"?>
+ * <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+ * <configuration>
+ *   <property>
+ *     <name>mapreduce.randomtextwriter.minwordskey</name>
+ *     <value>5</value>
+ *   </property>
+ *   <property>
+ *     <name>mapreduce.randomtextwriter.maxwordskey</name>
+ *     <value>10</value>
+ *   </property>
+ *   <property>
+ *     <name>mapreduce.randomtextwriter.minwordsvalue</name>
+ *     <value>20</value>
+ *   </property>
+ *   <property>
+ *     <name>mapreduce.randomtextwriter.maxwordsvalue</name>
+ *     <value>100</value>
+ *   </property>
+ *   <property>
+ *     <name>mapreduce.randomtextwriter.totalbytes</name>
+ *     <value>1099511627776</value>
+ *   </property>
+ * </configuration>}</pre>
+ * <p>
+ * Equivalently, {@link RandomTextWriter} also supports all the above options
+ * and ones supported by {@link Tool} via the command-line.
+ * <p>
+ * To run: bin/hadoop jar hadoop-${version}-examples.jar randomtextwriter
+ * [-outFormat <i>output format class</i>] <i>output</i>
+ */
+public class RandomTextWriter extends Configured implements Tool {
+    public static final String TOTAL_BYTES =
+            "mapreduce.randomtextwriter.totalbytes";
+    public static final String BYTES_PER_MAP =
+            "mapreduce.randomtextwriter.bytespermap";
+    public static final String MAPS_PER_HOST =
+            "mapreduce.randomtextwriter.mapsperhost";
+    public static final String MAX_VALUE = "mapreduce.randomtextwriter.maxwordsvalue";
+    public static final String MIN_VALUE = "mapreduce.randomtextwriter.minwordsvalue";
+    public static final String MIN_KEY = "mapreduce.randomtextwriter.minwordskey";
+    public static final String MAX_KEY = "mapreduce.randomtextwriter.maxwordskey";
+
+    static int printUsage() {
+        System.out.println("randomtextwriter " +
+                "<output> <uri> <scope> <stream>");
+        ToolRunner.printGenericCommandUsage(System.out);
+        return 2;
+    }
+
+    /**
+     * User counters
+     */
+    enum Counters {
+        RECORDS_WRITTEN, BYTES_WRITTEN
+    }
+
+    static class RandomTextMapper extends Mapper<Text, Text, String, Text> {
+
+        private long numBytesToWrite;
+        private int minWordsInKey;
+        private int wordsInKeyRange;
+        private int minWordsInValue;
+        private int wordsInValueRange;
+        private Random random = new Random();
+
+        /**
+         * Save the configuration value that we need to write the data.
+         */
+        public void setup(Context context) {
+            Configuration conf = context.getConfiguration();
+            numBytesToWrite = conf.getLong(BYTES_PER_MAP,
+                    1 * 1024 * 1024 * 1024);
+            minWordsInKey = conf.getInt(MIN_KEY, 5);
+            wordsInKeyRange = (conf.getInt(MAX_KEY, 10) - minWordsInKey);
+            minWordsInValue = conf.getInt(MIN_VALUE, 10);
+            wordsInValueRange = (conf.getInt(MAX_VALUE, 100) - minWordsInValue);
+        }
+
+        /**
+         * Given an output filename, write a bunch of random records to it.
+         */
+        public void map(Text key, Text value,
+                        Context context) throws IOException, InterruptedException {
+            int itemCount = 0;
+            while (numBytesToWrite > 0) {
+                // Generate the key/value
+                int noWordsKey = minWordsInKey +
+                        (wordsInKeyRange != 0 ? random.nextInt(wordsInKeyRange) : 0);
+                int noWordsValue = minWordsInValue +
+                        (wordsInValueRange != 0 ? random.nextInt(wordsInValueRange) : 0);
+                Text keyWords = generateSentence(noWordsKey);
+                Text valueWords = generateSentence(noWordsValue);
+
+                // Write the sentence, keyWords is just a routing key for Pravega, won't written to Pravega
+                context.write(keyWords.toString(), new Text(keyWords.toString() + valueWords.toString()));
+
+                numBytesToWrite -= (keyWords.getLength() + valueWords.getLength());
+
+                // Update counters, progress etc.
+                context.getCounter(Counters.BYTES_WRITTEN).increment(
+                        keyWords.getLength() + valueWords.getLength());
+                context.getCounter(Counters.RECORDS_WRITTEN).increment(1);
+                if (++itemCount % 200 == 0) {
+                    context.setStatus("wrote record " + itemCount + ". " +
+                            numBytesToWrite + " bytes left.");
+                }
+            }
+            context.setStatus("done with " + itemCount + " records.");
+        }
+
+        private Text generateSentence(int noWords) {
+            StringBuffer sentence = new StringBuffer();
+            String space = " ";
+            for (int i = 0; i < noWords; ++i) {
+                sentence.append(words[random.nextInt(words.length)]);
+                sentence.append(space);
+            }
+            return new Text(sentence.toString());
+        }
+    }
+
+    /**
+     * This is the main routine for launching a distributed random write job.
+     * It runs 10 maps/node and each node writes 1 gig of data to a DFS file.
+     * The reduce doesn't do anything.
+     *
+     * @throws IOException
+     */
+    public int run(String[] args) throws Exception {
+        if (args.length < 4) {
+            return printUsage();
+        }
+
+        Configuration conf = getConf();
+        JobClient client = new JobClient(conf);
+        ClusterStatus cluster = client.getClusterStatus();
+        int numMapsPerHost = conf.getInt(MAPS_PER_HOST, 10);
+        long numBytesToWritePerMap = conf.getLong(BYTES_PER_MAP,
+                1 * 1024 * 1024 * 1024);
+        if (numBytesToWritePerMap == 0) {
+            System.err.println("Cannot have " + BYTES_PER_MAP + " set to 0");
+            return -2;
+        }
+        long totalBytesToWrite = conf.getLong(TOTAL_BYTES,
+                numMapsPerHost * numBytesToWritePerMap * cluster.getTaskTrackers());
+        int numMaps = (int) (totalBytesToWrite / numBytesToWritePerMap);
+        if (numMaps == 0 && totalBytesToWrite > 0) {
+            numMaps = 1;
+            conf.setLong(BYTES_PER_MAP, totalBytesToWrite);
+        }
+        conf.setInt(MRJobConfig.NUM_MAPS, numMaps);
+
+        conf.setStrings("pravega.uri", args[1]);
+        conf.setStrings("pravega.scope", args[2]);
+        conf.setStrings("pravega.stream", args[3]);
+        conf.setStrings("pravega.deserializer", TextSerializer.class.getName());
+
+        Job job = Job.getInstance(conf);
+
+        job.setJarByClass(RandomTextWriter.class);
+        job.setJobName("random-text-writer");
+
+        job.setOutputKeyClass(String.class);
+        job.setOutputValueClass(Text.class);
+
+        job.setInputFormatClass(RandomWriter.RandomInputFormat.class);
+        job.setMapperClass(RandomTextMapper.class);
+        job.setOutputFormatClass(PravegaOutputFormat.class);
+        FileOutputFormat.setOutputPath(job, new Path(args[0]));
+
+        System.out.println("Running " + numMaps + " maps.");
+
+        // reducer NONE
+        job.setNumReduceTasks(0);
+
+        Date startTime = new Date();
+        System.out.println("Job started: " + startTime);
+        int ret = job.waitForCompletion(true) ? 0 : 1;
+        Date endTime = new Date();
+        System.out.println("Job ended: " + endTime);
+        System.out.println("The job took " +
+                (endTime.getTime() - startTime.getTime()) / 1000 +
+                " seconds.");
+
+        return ret;
+    }
+
+    public static void main(String[] args) throws Exception {
+        int res = ToolRunner.run(new Configuration(), new RandomTextWriter(), args);
+        System.exit(res);
+    }
+
+    /**
+     * A random list of 1000 words from /usr/share/dict/words
+     */
+    private static String[] words = {
+            "diurnalness", "Homoiousian",
+            "spiranthic", "tetragynian",
+            "silverhead", "ungreat",
+            "lithograph", "exploiter",
+            "physiologian", "by",
+            "hellbender", "Filipendula",
+            "undeterring", "antiscolic",
+            "pentagamist", "hypoid",
+            "cacuminal", "sertularian",
+            "schoolmasterism", "nonuple",
+            "gallybeggar", "phytonic",
+            "swearingly", "nebular",
+            "Confervales", "thermochemically",
+            "characinoid", "cocksuredom",
+            "fallacious", "feasibleness",
+            "debromination", "playfellowship",
+            "tramplike", "testa",
+            "participatingly", "unaccessible",
+            "bromate", "experientialist",
+            "roughcast", "docimastical",
+            "choralcelo", "blightbird",
+            "peptonate", "sombreroed",
+            "unschematized", "antiabolitionist",
+            "besagne", "mastication",
+            "bromic", "sviatonosite",
+            "cattimandoo", "metaphrastical",
+            "endotheliomyoma", "hysterolysis",
+            "unfulminated", "Hester",
+            "oblongly", "blurredness",
+            "authorling", "chasmy",
+            "Scorpaenidae", "toxihaemia",
+            "Dictograph", "Quakerishly",
+            "deaf", "timbermonger",
+            "strammel", "Thraupidae",
+            "seditious", "plerome",
+            "Arneb", "eristically",
+            "serpentinic", "glaumrie",
+            "socioromantic", "apocalypst",
+            "tartrous", "Bassaris",
+            "angiolymphoma", "horsefly",
+            "kenno", "astronomize",
+            "euphemious", "arsenide",
+            "untongued", "parabolicness",
+            "uvanite", "helpless",
+            "gemmeous", "stormy",
+            "templar", "erythrodextrin",
+            "comism", "interfraternal",
+            "preparative", "parastas",
+            "frontoorbital", "Ophiosaurus",
+            "diopside", "serosanguineous",
+            "ununiformly", "karyological",
+            "collegian", "allotropic",
+            "depravity", "amylogenesis",
+            "reformatory", "epidymides",
+            "pleurotropous", "trillium",
+            "dastardliness", "coadvice",
+            "embryotic", "benthonic",
+            "pomiferous", "figureheadship",
+            "Megaluridae", "Harpa",
+            "frenal", "commotion",
+            "abthainry", "cobeliever",
+            "manilla", "spiciferous",
+            "nativeness", "obispo",
+            "monilioid", "biopsic",
+            "valvula", "enterostomy",
+            "planosubulate", "pterostigma",
+            "lifter", "triradiated",
+            "venialness", "tum",
+            "archistome", "tautness",
+            "unswanlike", "antivenin",
+            "Lentibulariaceae", "Triphora",
+            "angiopathy", "anta",
+            "Dawsonia", "becomma",
+            "Yannigan", "winterproof",
+            "antalgol", "harr",
+            "underogating", "ineunt",
+            "cornberry", "flippantness",
+            "scyphostoma", "approbation",
+            "Ghent", "Macraucheniidae",
+            "scabbiness", "unanatomized",
+            "photoelasticity", "eurythermal",
+            "enation", "prepavement",
+            "flushgate", "subsequentially",
+            "Edo", "antihero",
+            "Isokontae", "unforkedness",
+            "porriginous", "daytime",
+            "nonexecutive", "trisilicic",
+            "morphiomania", "paranephros",
+            "botchedly", "impugnation",
+            "Dodecatheon", "obolus",
+            "unburnt", "provedore",
+            "Aktistetae", "superindifference",
+            "Alethea", "Joachimite",
+            "cyanophilous", "chorograph",
+            "brooky", "figured",
+            "periclitation", "quintette",
+            "hondo", "ornithodelphous",
+            "unefficient", "pondside",
+            "bogydom", "laurinoxylon",
+            "Shiah", "unharmed",
+            "cartful", "noncrystallized",
+            "abusiveness", "cromlech",
+            "japanned", "rizzomed",
+            "underskin", "adscendent",
+            "allectory", "gelatinousness",
+            "volcano", "uncompromisingly",
+            "cubit", "idiotize",
+            "unfurbelowed", "undinted",
+            "magnetooptics", "Savitar",
+            "diwata", "ramosopalmate",
+            "Pishquow", "tomorn",
+            "apopenptic", "Haversian",
+            "Hysterocarpus", "ten",
+            "outhue", "Bertat",
+            "mechanist", "asparaginic",
+            "velaric", "tonsure",
+            "bubble", "Pyrales",
+            "regardful", "glyphography",
+            "calabazilla", "shellworker",
+            "stradametrical", "havoc",
+            "theologicopolitical", "sawdust",
+            "diatomaceous", "jajman",
+            "temporomastoid", "Serrifera",
+            "Ochnaceae", "aspersor",
+            "trailmaking", "Bishareen",
+            "digitule", "octogynous",
+            "epididymitis", "smokefarthings",
+            "bacillite", "overcrown",
+            "mangonism", "sirrah",
+            "undecorated", "psychofugal",
+            "bismuthiferous", "rechar",
+            "Lemuridae", "frameable",
+            "thiodiazole", "Scanic",
+            "sportswomanship", "interruptedness",
+            "admissory", "osteopaedion",
+            "tingly", "tomorrowness",
+            "ethnocracy", "trabecular",
+            "vitally", "fossilism",
+            "adz", "metopon",
+            "prefatorial", "expiscate",
+            "diathermacy", "chronist",
+            "nigh", "generalizable",
+            "hysterogen", "aurothiosulphuric",
+            "whitlowwort", "downthrust",
+            "Protestantize", "monander",
+            "Itea", "chronographic",
+            "silicize", "Dunlop",
+            "eer", "componental",
+            "spot", "pamphlet",
+            "antineuritic", "paradisean",
+            "interruptor", "debellator",
+            "overcultured", "Florissant",
+            "hyocholic", "pneumatotherapy",
+            "tailoress", "rave",
+            "unpeople", "Sebastian",
+            "thermanesthesia", "Coniferae",
+            "swacking", "posterishness",
+            "ethmopalatal", "whittle",
+            "analgize", "scabbardless",
+            "naught", "symbiogenetically",
+            "trip", "parodist",
+            "columniform", "trunnel",
+            "yawler", "goodwill",
+            "pseudohalogen", "swangy",
+            "cervisial", "mediateness",
+            "genii", "imprescribable",
+            "pony", "consumptional",
+            "carposporangial", "poleax",
+            "bestill", "subfebrile",
+            "sapphiric", "arrowworm",
+            "qualminess", "ultraobscure",
+            "thorite", "Fouquieria",
+            "Bermudian", "prescriber",
+            "elemicin", "warlike",
+            "semiangle", "rotular",
+            "misthread", "returnability",
+            "seraphism", "precostal",
+            "quarried", "Babylonism",
+            "sangaree", "seelful",
+            "placatory", "pachydermous",
+            "bozal", "galbulus",
+            "spermaphyte", "cumbrousness",
+            "pope", "signifier",
+            "Endomycetaceae", "shallowish",
+            "sequacity", "periarthritis",
+            "bathysphere", "pentosuria",
+            "Dadaism", "spookdom",
+            "Consolamentum", "afterpressure",
+            "mutter", "louse",
+            "ovoviviparous", "corbel",
+            "metastoma", "biventer",
+            "Hydrangea", "hogmace",
+            "seizing", "nonsuppressed",
+            "oratorize", "uncarefully",
+            "benzothiofuran", "penult",
+            "balanocele", "macropterous",
+            "dishpan", "marten",
+            "absvolt", "jirble",
+            "parmelioid", "airfreighter",
+            "acocotl", "archesporial",
+            "hypoplastral", "preoral",
+            "quailberry", "cinque",
+            "terrestrially", "stroking",
+            "limpet", "moodishness",
+            "canicule", "archididascalian",
+            "pompiloid", "overstaid",
+            "introducer", "Italical",
+            "Christianopaganism", "prescriptible",
+            "subofficer", "danseuse",
+            "cloy", "saguran",
+            "frictionlessly", "deindividualization",
+            "Bulanda", "ventricous",
+            "subfoliar", "basto",
+            "scapuloradial", "suspend",
+            "stiffish", "Sphenodontidae",
+            "eternal", "verbid",
+            "mammonish", "upcushion",
+            "barkometer", "concretion",
+            "preagitate", "incomprehensible",
+            "tristich", "visceral",
+            "hemimelus", "patroller",
+            "stentorophonic", "pinulus",
+            "kerykeion", "brutism",
+            "monstership", "merciful",
+            "overinstruct", "defensibly",
+            "bettermost", "splenauxe",
+            "Mormyrus", "unreprimanded",
+            "taver", "ell",
+            "proacquittal", "infestation",
+            "overwoven", "Lincolnlike",
+            "chacona", "Tamil",
+            "classificational", "lebensraum",
+            "reeveland", "intuition",
+            "Whilkut", "focaloid",
+            "Eleusinian", "micromembrane",
+            "byroad", "nonrepetition",
+            "bacterioblast", "brag",
+            "ribaldrous", "phytoma",
+            "counteralliance", "pelvimetry",
+            "pelf", "relaster",
+            "thermoresistant", "aneurism",
+            "molossic", "euphonym",
+            "upswell", "ladhood",
+            "phallaceous", "inertly",
+            "gunshop", "stereotypography",
+            "laryngic", "refasten",
+            "twinling", "oflete",
+            "hepatorrhaphy", "electrotechnics",
+            "cockal", "guitarist",
+            "topsail", "Cimmerianism",
+            "larklike", "Llandovery",
+            "pyrocatechol", "immatchable",
+            "chooser", "metrocratic",
+            "craglike", "quadrennial",
+            "nonpoisonous", "undercolored",
+            "knob", "ultratense",
+            "balladmonger", "slait",
+            "sialadenitis", "bucketer",
+            "magnificently", "unstipulated",
+            "unscourged", "unsupercilious",
+            "packsack", "pansophism",
+            "soorkee", "percent",
+            "subirrigate", "champer",
+            "metapolitics", "spherulitic",
+            "involatile", "metaphonical",
+            "stachyuraceous", "speckedness",
+            "bespin", "proboscidiform",
+            "gul", "squit",
+            "yeelaman", "peristeropode",
+            "opacousness", "shibuichi",
+            "retinize", "yote",
+            "misexposition", "devilwise",
+            "pumpkinification", "vinny",
+            "bonze", "glossing",
+            "decardinalize", "transcortical",
+            "serphoid", "deepmost",
+            "guanajuatite", "wemless",
+            "arval", "lammy",
+            "Effie", "Saponaria",
+            "tetrahedral", "prolificy",
+            "excerpt", "dunkadoo",
+            "Spencerism", "insatiately",
+            "Gilaki", "oratorship",
+            "arduousness", "unbashfulness",
+            "Pithecolobium", "unisexuality",
+            "veterinarian", "detractive",
+            "liquidity", "acidophile",
+            "proauction", "sural",
+            "totaquina", "Vichyite",
+            "uninhabitedness", "allegedly",
+            "Gothish", "manny",
+            "Inger", "flutist",
+            "ticktick", "Ludgatian",
+            "homotransplant", "orthopedical",
+            "diminutively", "monogoneutic",
+            "Kenipsim", "sarcologist",
+            "drome", "stronghearted",
+            "Fameuse", "Swaziland",
+            "alen", "chilblain",
+            "beatable", "agglomeratic",
+            "constitutor", "tendomucoid",
+            "porencephalous", "arteriasis",
+            "boser", "tantivy",
+            "rede", "lineamental",
+            "uncontradictableness", "homeotypical",
+            "masa", "folious",
+            "dosseret", "neurodegenerative",
+            "subtransverse", "Chiasmodontidae",
+            "palaeotheriodont", "unstressedly",
+            "chalcites", "piquantness",
+            "lampyrine", "Aplacentalia",
+            "projecting", "elastivity",
+            "isopelletierin", "bladderwort",
+            "strander", "almud",
+            "iniquitously", "theologal",
+            "bugre", "chargeably",
+            "imperceptivity", "meriquinoidal",
+            "mesophyte", "divinator",
+            "perfunctory", "counterappellant",
+            "synovial", "charioteer",
+            "crystallographical", "comprovincial",
+            "infrastapedial", "pleasurehood",
+            "inventurous", "ultrasystematic",
+            "subangulated", "supraoesophageal",
+            "Vaishnavism", "transude",
+            "chrysochrous", "ungrave",
+            "reconciliable", "uninterpleaded",
+            "erlking", "wherefrom",
+            "aprosopia", "antiadiaphorist",
+            "metoxazine", "incalculable",
+            "umbellic", "predebit",
+            "foursquare", "unimmortal",
+            "nonmanufacture", "slangy",
+            "predisputant", "familist",
+            "preaffiliate", "friarhood",
+            "corelysis", "zoonitic",
+            "halloo", "paunchy",
+            "neuromimesis", "aconitine",
+            "hackneyed", "unfeeble",
+            "cubby", "autoschediastical",
+            "naprapath", "lyrebird",
+            "inexistency", "leucophoenicite",
+            "ferrogoslarite", "reperuse",
+            "uncombable", "tambo",
+            "propodiale", "diplomatize",
+            "Russifier", "clanned",
+            "corona", "michigan",
+            "nonutilitarian", "transcorporeal",
+            "bought", "Cercosporella",
+            "stapedius", "glandularly",
+            "pictorially", "weism",
+            "disilane", "rainproof",
+            "Caphtor", "scrubbed",
+            "oinomancy", "pseudoxanthine",
+            "nonlustrous", "redesertion",
+            "Oryzorictinae", "gala",
+            "Mycogone", "reappreciate",
+            "cyanoguanidine", "seeingness",
+            "breadwinner", "noreast",
+            "furacious", "epauliere",
+            "omniscribent", "Passiflorales",
+            "uninductive", "inductivity",
+            "Orbitolina", "Semecarpus",
+            "migrainoid", "steprelationship",
+            "phlogisticate", "mesymnion",
+            "sloped", "edificator",
+            "beneficent", "culm",
+            "paleornithology", "unurban",
+            "throbless", "amplexifoliate",
+            "sesquiquintile", "sapience",
+            "astucious", "dithery",
+            "boor", "ambitus",
+            "scotching", "uloid",
+            "uncompromisingness", "hoove",
+            "waird", "marshiness",
+            "Jerusalem", "mericarp",
+            "unevoked", "benzoperoxide",
+            "outguess", "pyxie",
+            "hymnic", "euphemize",
+            "mendacity", "erythremia",
+            "rosaniline", "unchatteled",
+            "lienteria", "Bushongo",
+            "dialoguer", "unrepealably",
+            "rivethead", "antideflation",
+            "vinegarish", "manganosiderite",
+            "doubtingness", "ovopyriform",
+            "Cephalodiscus", "Muscicapa",
+            "Animalivora", "angina",
+            "planispheric", "ipomoein",
+            "cuproiodargyrite", "sandbox",
+            "scrat", "Munnopsidae",
+            "shola", "pentafid",
+            "overstudiousness", "times",
+            "nonprofession", "appetible",
+            "valvulotomy", "goladar",
+            "uniarticular", "oxyterpene",
+            "unlapsing", "omega",
+            "trophonema", "seminonflammable",
+            "circumzenithal", "starer",
+            "depthwise", "liberatress",
+            "unleavened", "unrevolting",
+            "groundneedle", "topline",
+            "wandoo", "umangite",
+            "ordinant", "unachievable",
+            "oversand", "snare",
+            "avengeful", "unexplicit",
+            "mustafina", "sonable",
+            "rehabilitative", "eulogization",
+            "papery", "technopsychology",
+            "impressor", "cresylite",
+            "entame", "transudatory",
+            "scotale", "pachydermatoid",
+            "imaginary", "yeat",
+            "slipped", "stewardship",
+            "adatom", "cockstone",
+            "skyshine", "heavenful",
+            "comparability", "exprobratory",
+            "dermorhynchous", "parquet",
+            "cretaceous", "vesperal",
+            "raphis", "undangered",
+            "Glecoma", "engrain",
+            "counteractively", "Zuludom",
+            "orchiocatabasis", "Auriculariales",
+            "warriorwise", "extraorganismal",
+            "overbuilt", "alveolite",
+            "tetchy", "terrificness",
+            "widdle", "unpremonished",
+            "rebilling", "sequestrum",
+            "equiconvex", "heliocentricism",
+            "catabaptist", "okonite",
+            "propheticism", "helminthagogic",
+            "calycular", "giantly",
+            "wingable", "golem",
+            "unprovided", "commandingness",
+            "greave", "haply",
+            "doina", "depressingly",
+            "subdentate", "impairment",
+            "decidable", "neurotrophic",
+            "unpredict", "bicorporeal",
+            "pendulant", "flatman",
+            "intrabred", "toplike",
+            "Prosobranchiata", "farrantly",
+            "toxoplasmosis", "gorilloid",
+            "dipsomaniacal", "aquiline",
+            "atlantite", "ascitic",
+            "perculsive", "prospectiveness",
+            "saponaceous", "centrifugalization",
+            "dinical", "infravaginal",
+            "beadroll", "affaite",
+            "Helvidian", "tickleproof",
+            "abstractionism", "enhedge",
+            "outwealth", "overcontribute",
+            "coldfinch", "gymnastic",
+            "Pincian", "Munychian",
+            "codisjunct", "quad",
+            "coracomandibular", "phoenicochroite",
+            "amender", "selectivity",
+            "putative", "semantician",
+            "lophotrichic", "Spatangoidea",
+            "saccharogenic", "inferent",
+            "Triconodonta", "arrendation",
+            "sheepskin", "taurocolla",
+            "bunghole", "Machiavel",
+            "triakistetrahedral", "dehairer",
+            "prezygapophysial", "cylindric",
+            "pneumonalgia", "sleigher",
+            "emir", "Socraticism",
+            "licitness", "massedly",
+            "instructiveness", "sturdied",
+            "redecrease", "starosta",
+            "evictor", "orgiastic",
+            "squdge", "meloplasty",
+            "Tsonecan", "repealableness",
+            "swoony", "myesthesia",
+            "molecule", "autobiographist",
+            "reciprocation", "refective",
+            "unobservantness", "tricae",
+            "ungouged", "floatability",
+            "Mesua", "fetlocked",
+            "chordacentrum", "sedentariness",
+            "various", "laubanite",
+            "nectopod", "zenick",
+            "sequentially", "analgic",
+            "biodynamics", "posttraumatic",
+            "nummi", "pyroacetic",
+            "bot", "redescend",
+            "dispermy", "undiffusive",
+            "circular", "trillion",
+            "Uraniidae", "ploration",
+            "discipular", "potentness",
+            "sud", "Hu",
+            "Eryon", "plugger",
+            "subdrainage", "jharal",
+            "abscission", "supermarket",
+            "countergabion", "glacierist",
+            "lithotresis", "minniebush",
+            "zanyism", "eucalypteol",
+            "sterilely", "unrealize",
+            "unpatched", "hypochondriacism",
+            "critically", "cheesecutter",
+    };
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomTextWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomTextWriter.java
@@ -29,6 +29,9 @@ import java.util.Random;
  * This class is copied from apache/hadoop and modified by adding logic to
  * support PravegaInputFormat
  *
+ * https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-examples
+ * /src/main/java/org/apache/hadoop/examples/RandomTextWriter.java
+ *
  * This program uses map/reduce to just run a distributed job where there is
  * no interaction between the tasks and each task writes a large unsorted
  * random sequence of words.

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomWriter.java
@@ -1,21 +1,11 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.examples.hadoop;
@@ -44,6 +34,9 @@ import java.util.List;
 import java.util.Random;
 
 /**
+ *
+ * This class is copied from apache/hadoop
+ *
  * This program uses map/reduce to just run a distributed job where there is
  * no interaction between the tasks and each task write a large unsorted
  * random binary sequence file of BytesWritable.

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomWriter.java
@@ -37,6 +37,9 @@ import java.util.Random;
  *
  * This class is copied from apache/hadoop
  *
+ * https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-examples
+ * /src/main/java/org/apache/hadoop/examples/RandomWriter.java
+ *
  * This program uses map/reduce to just run a distributed job where there is
  * no interaction between the tasks and each task write a large unsorted
  * random binary sequence file of BytesWritable.

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomWriter.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomWriter.java
@@ -1,0 +1,303 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ */
+
+package io.pravega.examples.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.mapred.ClusterStatus;
+import org.apache.hadoop.mapred.JobClient;
+import org.apache.hadoop.mapreduce.*;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
+import org.apache.hadoop.util.GenericOptionsParser;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * This program uses map/reduce to just run a distributed job where there is
+ * no interaction between the tasks and each task write a large unsorted
+ * random binary sequence file of BytesWritable.
+ * In order for this program to generate data for terasort with 10-byte keys
+ * and 90-byte values, have the following config:
+ * <pre>{@code
+ * <?xml version="1.0"?>
+ * <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+ * <configuration>
+ *   <property>
+ *     <name>mapreduce.randomwriter.minkey</name>
+ *     <value>10</value>
+ *   </property>
+ *   <property>
+ *     <name>mapreduce.randomwriter.maxkey</name>
+ *     <value>10</value>
+ *   </property>
+ *   <property>
+ *     <name>mapreduce.randomwriter.minvalue</name>
+ *     <value>90</value>
+ *   </property>
+ *   <property>
+ *     <name>mapreduce.randomwriter.maxvalue</name>
+ *     <value>90</value>
+ *   </property>
+ *   <property>
+ *     <name>mapreduce.randomwriter.totalbytes</name>
+ *     <value>1099511627776</value>
+ *   </property>
+ * </configuration>}</pre>
+ * Equivalently, {@link RandomWriter} also supports all the above options
+ * and ones supported by {@link GenericOptionsParser} via the command-line.
+ */
+public class RandomWriter extends Configured implements Tool {
+    public static final String TOTAL_BYTES = "mapreduce.randomwriter.totalbytes";
+    public static final String BYTES_PER_MAP =
+            "mapreduce.randomwriter.bytespermap";
+    public static final String MAPS_PER_HOST =
+            "mapreduce.randomwriter.mapsperhost";
+    public static final String MAX_VALUE = "mapreduce.randomwriter.maxvalue";
+    public static final String MIN_VALUE = "mapreduce.randomwriter.minvalue";
+    public static final String MIN_KEY = "mapreduce.randomwriter.minkey";
+    public static final String MAX_KEY = "mapreduce.randomwriter.maxkey";
+
+    /**
+     * User counters
+     */
+    enum Counters {
+        RECORDS_WRITTEN, BYTES_WRITTEN
+    }
+
+    /**
+     * A custom input format that creates virtual inputs of a single string
+     * for each map.
+     */
+    static class RandomInputFormat extends InputFormat<Text, Text> {
+
+        /**
+         * Generate the requested number of file splits, with the filename
+         * set to the filename of the output file.
+         */
+        public List<InputSplit> getSplits(JobContext job) throws IOException {
+            List<InputSplit> result = new ArrayList<InputSplit>();
+            Path outDir = FileOutputFormat.getOutputPath(job);
+            int numSplits =
+                    job.getConfiguration().getInt(MRJobConfig.NUM_MAPS, 1);
+            for (int i = 0; i < numSplits; ++i) {
+                result.add(new FileSplit(new Path(outDir, "dummy-split-" + i), 0, 1,
+                        (String[]) null));
+            }
+            return result;
+        }
+
+        /**
+         * Return a single record (filename, "") where the filename is taken from
+         * the file split.
+         */
+        static class RandomRecordReader extends RecordReader<Text, Text> {
+            Path name;
+            Text key = null;
+            Text value = new Text();
+
+            public RandomRecordReader(Path p) {
+                name = p;
+            }
+
+            public void initialize(InputSplit split,
+                                   TaskAttemptContext context)
+                    throws IOException, InterruptedException {
+
+            }
+
+            public boolean nextKeyValue() {
+                if (name != null) {
+                    key = new Text();
+                    key.set(name.getName());
+                    name = null;
+                    return true;
+                }
+                return false;
+            }
+
+            public Text getCurrentKey() {
+                return key;
+            }
+
+            public Text getCurrentValue() {
+                return value;
+            }
+
+            public void close() {
+            }
+
+            public float getProgress() {
+                return 0.0f;
+            }
+        }
+
+        public RecordReader<Text, Text> createRecordReader(InputSplit split,
+                                                           TaskAttemptContext context) throws IOException, InterruptedException {
+            return new RandomRecordReader(((FileSplit) split).getPath());
+        }
+    }
+
+    static class RandomMapper extends Mapper<WritableComparable, Writable,
+            BytesWritable, BytesWritable> {
+
+        private long numBytesToWrite;
+        private int minKeySize;
+        private int keySizeRange;
+        private int minValueSize;
+        private int valueSizeRange;
+        private Random random = new Random();
+        private BytesWritable randomKey = new BytesWritable();
+        private BytesWritable randomValue = new BytesWritable();
+
+        private void randomizeBytes(byte[] data, int offset, int length) {
+            for (int i = offset + length - 1; i >= offset; --i) {
+                data[i] = (byte) random.nextInt(256);
+            }
+        }
+
+        /**
+         * Given an output filename, write a bunch of random records to it.
+         */
+        public void map(WritableComparable key,
+                        Writable value,
+                        Context context) throws IOException, InterruptedException {
+            int itemCount = 0;
+            while (numBytesToWrite > 0) {
+                int keyLength = minKeySize +
+                        (keySizeRange != 0 ? random.nextInt(keySizeRange) : 0);
+                randomKey.setSize(keyLength);
+                randomizeBytes(randomKey.getBytes(), 0, randomKey.getLength());
+                int valueLength = minValueSize +
+                        (valueSizeRange != 0 ? random.nextInt(valueSizeRange) : 0);
+                randomValue.setSize(valueLength);
+                randomizeBytes(randomValue.getBytes(), 0, randomValue.getLength());
+                context.write(randomKey, randomValue);
+                numBytesToWrite -= keyLength + valueLength;
+                context.getCounter(Counters.BYTES_WRITTEN).increment(keyLength + valueLength);
+                context.getCounter(Counters.RECORDS_WRITTEN).increment(1);
+                if (++itemCount % 200 == 0) {
+                    context.setStatus("wrote record " + itemCount + ". " +
+                            numBytesToWrite + " bytes left.");
+                }
+            }
+            context.setStatus("done with " + itemCount + " records.");
+        }
+
+        /**
+         * Save the values out of the configuaration that we need to write
+         * the data.
+         */
+        @Override
+        public void setup(Context context) {
+            Configuration conf = context.getConfiguration();
+            numBytesToWrite = conf.getLong(BYTES_PER_MAP,
+                    1 * 1024 * 1024 * 1024);
+            minKeySize = conf.getInt(MIN_KEY, 10);
+            keySizeRange =
+                    conf.getInt(MAX_KEY, 1000) - minKeySize;
+            minValueSize = conf.getInt(MIN_VALUE, 0);
+            valueSizeRange =
+                    conf.getInt(MAX_VALUE, 20000) - minValueSize;
+        }
+    }
+
+    /**
+     * This is the main routine for launching a distributed random write job.
+     * It runs 10 maps/node and each node writes 1 gig of data to a DFS file.
+     * The reduce doesn't do anything.
+     *
+     * @throws IOException
+     */
+    public int run(String[] args) throws Exception {
+        if (args.length == 0) {
+            System.out.println("Usage: writer <out-dir>");
+            ToolRunner.printGenericCommandUsage(System.out);
+            return 2;
+        }
+
+        Path outDir = new Path(args[0]);
+        Configuration conf = getConf();
+        JobClient client = new JobClient(conf);
+        ClusterStatus cluster = client.getClusterStatus();
+        int numMapsPerHost = conf.getInt(MAPS_PER_HOST, 10);
+        long numBytesToWritePerMap = conf.getLong(BYTES_PER_MAP,
+                1 * 1024 * 1024 * 1024);
+        if (numBytesToWritePerMap == 0) {
+            System.err.println("Cannot have" + BYTES_PER_MAP + " set to 0");
+            return -2;
+        }
+        long totalBytesToWrite = conf.getLong(TOTAL_BYTES,
+                numMapsPerHost * numBytesToWritePerMap * cluster.getTaskTrackers());
+        int numMaps = (int) (totalBytesToWrite / numBytesToWritePerMap);
+        if (numMaps == 0 && totalBytesToWrite > 0) {
+            numMaps = 1;
+            conf.setLong(BYTES_PER_MAP, totalBytesToWrite);
+        }
+        conf.setInt(MRJobConfig.NUM_MAPS, numMaps);
+
+        Job job = Job.getInstance(conf);
+
+        job.setJarByClass(RandomWriter.class);
+        job.setJobName("random-writer");
+        FileOutputFormat.setOutputPath(job, outDir);
+        job.setOutputKeyClass(BytesWritable.class);
+        job.setOutputValueClass(BytesWritable.class);
+        job.setInputFormatClass(RandomInputFormat.class);
+        job.setMapperClass(RandomMapper.class);
+        job.setReducerClass(Reducer.class);
+        job.setOutputFormatClass(SequenceFileOutputFormat.class);
+
+        System.out.println("Running " + numMaps + " maps.");
+
+        // reducer NONE
+        job.setNumReduceTasks(0);
+
+        Date startTime = new Date();
+        System.out.println("Job started: " + startTime);
+        int ret = job.waitForCompletion(true) ? 0 : 1;
+        Date endTime = new Date();
+        System.out.println("Job ended: " + endTime);
+        System.out.println("The job took " +
+                (endTime.getTime() - startTime.getTime()) / 1000 +
+                " seconds.");
+
+        return ret;
+    }
+
+    public static void main(String[] args) throws Exception {
+        int res = ToolRunner.run(new Configuration(), new RandomWriter(), args);
+        System.exit(res);
+    }
+
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/TextSerializer.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/TextSerializer.java
@@ -1,12 +1,13 @@
 /**
  * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
+
 package io.pravega.examples.hadoop;
 
 import io.pravega.client.stream.Serializer;

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/TextSerializer.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/TextSerializer.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.examples.hadoop;
+
+import io.pravega.client.stream.Serializer;
+import lombok.EqualsAndHashCode;
+import org.apache.hadoop.io.Text;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+
+/**
+ * An implementation of {@link Serializer} that uses serialization.
+ */
+@EqualsAndHashCode
+public class TextSerializer implements Serializer<Text>, Serializable {
+
+    @Override
+    public ByteBuffer serialize(Text value) {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        ObjectOutputStream oout;
+        try {
+            oout = new ObjectOutputStream(bout);
+            value.write(oout);
+            oout.close();
+            bout.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return ByteBuffer.wrap(bout.toByteArray());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Text deserialize(ByteBuffer serializedValue) {
+        ByteArrayInputStream bin = new ByteArrayInputStream(serializedValue.array(),
+                serializedValue.position(),
+                serializedValue.remaining());
+        ObjectInputStream oin;
+        Text value = new Text();
+        try {
+            oin = new ObjectInputStream(bin);
+            value.readFields(oin);
+            return value;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordCount.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordCount.java
@@ -35,6 +35,9 @@ import com.google.common.base.Charsets;
  * This class is copied from apache/hadoop and modified by adding logic to
  * support PravegaInputFormat
  *
+ * https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-examples
+ * /src/main/java/org/apache/hadoop/examples/WordCount.java
+ *
  */
 public class WordCount {
 

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordCount.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordCount.java
@@ -1,22 +1,13 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
+
 package io.pravega.examples.hadoop;
 
 import io.pravega.connectors.hadoop.PravegaInputFormat;
@@ -39,6 +30,12 @@ import java.util.StringTokenizer;
 
 import com.google.common.base.Charsets;
 
+
+/**
+ * This class is copied from apache/hadoop and modified by adding logic to
+ * support PravegaInputFormat
+ *
+ */
 public class WordCount {
 
     public static class TokenizerMapper

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordCount.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordCount.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ */
+package io.pravega.examples.hadoop;
+
+import io.pravega.connectors.hadoop.PravegaInputFormat;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.util.GenericOptionsParser;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+import com.google.common.base.Charsets;
+
+public class WordCount {
+
+    public static class TokenizerMapper
+            extends Mapper<Object, Text, Text, IntWritable> {
+
+        private final static IntWritable one = new IntWritable(1);
+        private Text word = new Text();
+
+        public void map(Object ignored, Text value, Context context
+        ) throws IOException, InterruptedException {
+            StringTokenizer itr = new StringTokenizer(value.toString());
+            while (itr.hasMoreTokens()) {
+                word.set(itr.nextToken());
+                context.write(word, one);
+            }
+        }
+    }
+
+    public static class IntSumReducer
+            extends Reducer<Text, IntWritable, Text, IntWritable> {
+        private IntWritable result = new IntWritable();
+
+        public void reduce(Text key, Iterable<IntWritable> values,
+                           Context context
+        ) throws IOException, InterruptedException {
+            int sum = 0;
+            for (IntWritable val : values) {
+                sum += val.get();
+            }
+            result.set(sum);
+            context.write(key, result);
+        }
+    }
+
+    /**
+     * Reads the output file
+     *
+     * @param path The path to find the output file in. Set in main to the output
+     *             directory.
+     * @throws IOException If it cannot access the output directory, we throw an exception.
+     */
+    private static void readAndPrint(Path path, Configuration conf)
+            throws IOException {
+        FileSystem fs = FileSystem.get(conf);
+        Path file = new Path(path, "part-r-00000");
+
+        if (!fs.exists(file))
+            throw new IOException("Output not found!");
+
+        BufferedReader br = null;
+
+        try {
+            br = new BufferedReader(new InputStreamReader(fs.open(file), Charsets.UTF_8));
+            long count = 0;
+            long length = 0;
+
+            String line;
+            while ((line = br.readLine()) != null) {
+                System.out.println(line);
+            }
+        } finally {
+            if (br != null) {
+                br.close();
+            }
+        }
+    }
+
+
+    public static void main(String[] args) throws Exception {
+        Configuration conf = new Configuration();
+        String[] otherArgs = new GenericOptionsParser(conf, args).getRemainingArgs();
+        if (otherArgs.length < 5) {
+            System.err.println("Usage: wordcount <dummy_hdfs> <uri> <scope> <stream> <out>");
+            System.exit(2);
+        }
+
+        conf.setStrings("pravega.uri", otherArgs[1]);
+        conf.setStrings("pravega.scope", otherArgs[2]);
+        conf.setStrings("pravega.stream", otherArgs[3]);
+        conf.setStrings("pravega.deserializer", TextSerializer.class.getName());
+
+        Job job = Job.getInstance(conf, "word count");
+        job.setJarByClass(WordCount.class);
+        job.setMapperClass(TokenizerMapper.class);
+        job.setCombinerClass(IntSumReducer.class);
+        job.setReducerClass(IntSumReducer.class);
+        job.setOutputKeyClass(Text.class);
+        job.setOutputValueClass(IntWritable.class);
+
+        job.setInputFormatClass(PravegaInputFormat.class);
+
+        FileInputFormat.addInputPath(job, new Path(otherArgs[0]));
+        Path outputpath = new Path(otherArgs[4]);
+        FileOutputFormat.setOutputPath(job, outputpath);
+
+        boolean result = job.waitForCompletion(true);
+        readAndPrint(outputpath, conf);
+        System.exit(result ? 0 : 1);
+    }
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMean.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMean.java
@@ -1,0 +1,208 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ */
+
+package io.pravega.examples.hadoop;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+import io.pravega.connectors.hadoop.PravegaInputFormat;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+
+import com.google.common.base.Charsets;
+
+public class WordMean extends Configured implements Tool {
+
+    private double mean = 0;
+
+    private final static Text COUNT = new Text("count");
+    private final static Text LENGTH = new Text("length");
+    private final static LongWritable ONE = new LongWritable(1);
+
+    /**
+     * Maps words from line of text into 2 key-value pairs; one key-value pair for
+     * counting the word, another for counting its length.
+     */
+    public static class WordMeanMapper extends
+            Mapper<Object, Text, Text, LongWritable> {
+
+        private LongWritable wordLen = new LongWritable();
+
+        /**
+         * Emits 2 key-value pairs for counting the word and its length. Outputs are
+         * (Text, LongWritable).
+         *
+         * @param value
+         *          This will be a line of text coming in from our input file.
+         */
+        public void map(Object key, Text value, Context context)
+                throws IOException, InterruptedException {
+            StringTokenizer itr = new StringTokenizer(value.toString());
+            while (itr.hasMoreTokens()) {
+                String string = itr.nextToken();
+                this.wordLen.set(string.length());
+                context.write(LENGTH, this.wordLen);
+                context.write(COUNT, ONE);
+            }
+        }
+    }
+
+    /**
+     * Performs integer summation of all the values for each key.
+     */
+    public static class WordMeanReducer extends
+            Reducer<Text, LongWritable, Text, LongWritable> {
+
+        private LongWritable sum = new LongWritable();
+
+        /**
+         * Sums all the individual values within the iterator and writes them to the
+         * same key.
+         *
+         * @param key
+         *          This will be one of 2 constants: LENGTH_STR or COUNT_STR.
+         * @param values
+         *          This will be an iterator of all the values associated with that
+         *          key.
+         */
+        public void reduce(Text key, Iterable<LongWritable> values, Context context)
+                throws IOException, InterruptedException {
+
+            int theSum = 0;
+            for (LongWritable val : values) {
+                theSum += val.get();
+            }
+            sum.set(theSum);
+            context.write(key, sum);
+        }
+    }
+
+    /**
+     * Reads the output file and parses the summation of lengths, and the word
+     * count, to perform a quick calculation of the mean.
+     *
+     * @param path
+     *          The path to find the output file in. Set in main to the output
+     *          directory.
+     * @throws IOException
+     *           If it cannot access the output directory, we throw an exception.
+     */
+    private double readAndCalcMean(Path path, Configuration conf)
+            throws IOException {
+        FileSystem fs = FileSystem.get(conf);
+        Path file = new Path(path, "part-r-00000");
+
+        if (!fs.exists(file))
+            throw new IOException("Output not found!");
+
+        BufferedReader br = null;
+
+        // average = total sum / number of elements;
+        try {
+            br = new BufferedReader(new InputStreamReader(fs.open(file), Charsets.UTF_8));
+
+            long count = 0;
+            long length = 0;
+
+            String line;
+            while ((line = br.readLine()) != null) {
+                StringTokenizer st = new StringTokenizer(line);
+
+                // grab type
+                String type = st.nextToken();
+
+                // differentiate
+                if (type.equals(COUNT.toString())) {
+                    String countLit = st.nextToken();
+                    count = Long.parseLong(countLit);
+                } else if (type.equals(LENGTH.toString())) {
+                    String lengthLit = st.nextToken();
+                    length = Long.parseLong(lengthLit);
+                }
+            }
+
+            double theMean = (((double) length) / ((double) count));
+            System.out.println("The mean is: " + theMean);
+            return theMean;
+        } finally {
+            if (br != null) {
+                br.close();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ToolRunner.run(new Configuration(), new WordMean(), args);
+    }
+
+    @Override
+    public int run(String[] args) throws Exception {
+        if (args.length != 5) {
+            System.err.println("Usage: wordmean <dummy_hdfs> <uri> <scope> <stream> <out>");
+            return 0;
+        }
+
+        Configuration conf = getConf();
+
+        conf.setStrings("pravega.uri", args[1]);
+        conf.setStrings("pravega.scope", args[2]);
+        conf.setStrings("pravega.stream", args[3]);
+        conf.setStrings("pravega.deserializer", TextSerializer.class.getName());
+
+        Job job = Job.getInstance(conf, "word mean");
+        job.setJarByClass(WordMean.class);
+        job.setMapperClass(WordMeanMapper.class);
+        job.setCombinerClass(WordMeanReducer.class);
+        job.setReducerClass(WordMeanReducer.class);
+        job.setOutputKeyClass(Text.class);
+        job.setOutputValueClass(LongWritable.class);
+        job.setInputFormatClass(PravegaInputFormat.class);
+        FileInputFormat.addInputPath(job, new Path(args[0]));
+        Path outputpath = new Path(args[4]);
+        FileOutputFormat.setOutputPath(job, outputpath);
+        boolean result = job.waitForCompletion(true);
+        mean = readAndCalcMean(outputpath, conf);
+
+        return (result ? 0 : 1);
+    }
+
+    /**
+     * Only valuable after run() called.
+     *
+     * @return Returns the mean value.
+     */
+    public double getMean() {
+        return mean;
+    }
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMean.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMean.java
@@ -1,21 +1,11 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.examples.hadoop;
@@ -42,6 +32,11 @@ import org.apache.hadoop.util.ToolRunner;
 
 import com.google.common.base.Charsets;
 
+/**
+ * This class is copied from apache/hadoop and modified by adding logic to
+ * support PravegaInputFormat
+ *
+ */
 public class WordMean extends Configured implements Tool {
 
     private double mean = 0;

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMean.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMean.java
@@ -36,6 +36,9 @@ import com.google.common.base.Charsets;
  * This class is copied from apache/hadoop and modified by adding logic to
  * support PravegaInputFormat
  *
+ * https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-examples
+ * /src/main/java/org/apache/hadoop/examples/WordMean.java
+ *
  */
 public class WordMean extends Configured implements Tool {
 

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMedian.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMedian.java
@@ -1,0 +1,220 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ */
+
+package io.pravega.examples.hadoop;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+import io.pravega.connectors.hadoop.PravegaInputFormat;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.TaskCounter;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+
+import com.google.common.base.Charsets;
+
+public class WordMedian extends Configured implements Tool {
+
+    private double median = 0;
+    private final static IntWritable ONE = new IntWritable(1);
+
+    /**
+     * Maps words from line of text into a key-value pair; the length of the word
+     * as the key, and 1 as the value.
+     */
+    public static class WordMedianMapper extends
+            Mapper<Object, Text, IntWritable, IntWritable> {
+
+        private IntWritable length = new IntWritable();
+
+        /**
+         * Emits a key-value pair for counting the word. Outputs are (IntWritable,
+         * IntWritable).
+         *
+         * @param value
+         *          This will be a line of text coming in from our input file.
+         */
+        public void map(Object key, Text value, Context context)
+                throws IOException, InterruptedException {
+            StringTokenizer itr = new StringTokenizer(value.toString());
+            while (itr.hasMoreTokens()) {
+                String string = itr.nextToken();
+                length.set(string.length());
+                context.write(length, ONE);
+            }
+        }
+    }
+
+    /**
+     * Performs integer summation of all the values for each key.
+     */
+    public static class WordMedianReducer extends
+            Reducer<IntWritable, IntWritable, IntWritable, IntWritable> {
+
+        private IntWritable val = new IntWritable();
+
+        /**
+         * Sums all the individual values within the iterator and writes them to the
+         * same key.
+         *
+         * @param key
+         *          This will be a length of a word that was read.
+         * @param values
+         *          This will be an iterator of all the values associated with that
+         *          key.
+         */
+        public void reduce(IntWritable key, Iterable<IntWritable> values,
+                           Context context) throws IOException, InterruptedException {
+
+            int sum = 0;
+            for (IntWritable value : values) {
+                sum += value.get();
+            }
+            val.set(sum);
+            context.write(key, val);
+        }
+    }
+
+    /**
+     * This is a standard program to read and find a median value based on a file
+     * of word counts such as: 1 456, 2 132, 3 56... Where the first values are
+     * the word lengths and the following values are the number of times that
+     * words of that length appear.
+     *
+     * @param path
+     *          The path to read the HDFS file from (part-r-00000...00001...etc).
+     * @param medianIndex1
+     *          The first length value to look for.
+     * @param medianIndex2
+     *          The second length value to look for (will be the same as the first
+     *          if there are an even number of words total).
+     * @throws IOException
+     *           If file cannot be found, we throw an exception.
+     * */
+    private double readAndFindMedian(String path, int medianIndex1,
+                                     int medianIndex2, Configuration conf) throws IOException {
+        FileSystem fs = FileSystem.get(conf);
+        Path file = new Path(path, "part-r-00000");
+
+        if (!fs.exists(file))
+            throw new IOException("Output not found!");
+
+        BufferedReader br = null;
+
+        try {
+            br = new BufferedReader(new InputStreamReader(fs.open(file), Charsets.UTF_8));
+            int num = 0;
+
+            String line;
+            while ((line = br.readLine()) != null) {
+                StringTokenizer st = new StringTokenizer(line);
+
+                // grab length
+                String currLen = st.nextToken();
+
+                // grab count
+                String lengthFreq = st.nextToken();
+
+                int prevNum = num;
+                num += Integer.parseInt(lengthFreq);
+
+                if (medianIndex2 >= prevNum && medianIndex1 <= num) {
+                    System.out.println("The median is: " + currLen);
+                    br.close();
+                    return Double.parseDouble(currLen);
+                } else if (medianIndex2 >= prevNum && medianIndex1 < num) {
+                    String nextCurrLen = st.nextToken();
+                    double theMedian = (Integer.parseInt(currLen) + Integer
+                            .parseInt(nextCurrLen)) / 2.0;
+                    System.out.println("The median is: " + theMedian);
+                    br.close();
+                    return theMedian;
+                }
+            }
+        } finally {
+            if (br != null) {
+                br.close();
+            }
+        }
+        // error, no median found
+        return -1;
+    }
+
+    public static void main(String[] args) throws Exception {
+        ToolRunner.run(new Configuration(), new WordMedian(), args);
+    }
+
+    @Override
+    public int run(String[] args) throws Exception {
+        if (args.length != 5) {
+            System.err.println("Usage: wordmedian <dummy_hdfs> <uri> <scope> <stream> <out>");
+            return 0;
+        }
+
+        setConf(new Configuration());
+        Configuration conf = getConf();
+
+        conf.setStrings("pravega.uri", args[1]);
+        conf.setStrings("pravega.scope", args[2]);
+        conf.setStrings("pravega.stream", args[3]);
+        conf.setStrings("pravega.deserializer", TextSerializer.class.getName());
+
+        Job job = Job.getInstance(conf, "word median");
+        job.setJarByClass(WordMedian.class);
+        job.setMapperClass(WordMedianMapper.class);
+        job.setCombinerClass(WordMedianReducer.class);
+        job.setReducerClass(WordMedianReducer.class);
+        job.setOutputKeyClass(IntWritable.class);
+        job.setOutputValueClass(IntWritable.class);
+        job.setInputFormatClass(PravegaInputFormat.class);
+        FileInputFormat.addInputPath(job, new Path(args[0]));
+        FileOutputFormat.setOutputPath(job, new Path(args[4]));
+        boolean result = job.waitForCompletion(true);
+
+        // Wait for JOB 1 -- get middle value to check for Median
+
+        long totalWords = job.getCounters()
+                .getGroup(TaskCounter.class.getCanonicalName())
+                .findCounter("MAP_OUTPUT_RECORDS", "Map output records").getValue();
+        int medianIndex1 = (int) Math.ceil((totalWords / 2.0));
+        int medianIndex2 = (int) Math.floor((totalWords / 2.0));
+
+        median = readAndFindMedian(args[4], medianIndex1, medianIndex2, conf);
+
+        return (result ? 0 : 1);
+    }
+
+    public double getMedian() {
+        return median;
+    }
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMedian.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMedian.java
@@ -1,21 +1,11 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
  *
- * Modified by Dell Inc. 2018 to support PravegaOutoutFormat
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.examples.hadoop;
@@ -43,6 +33,11 @@ import org.apache.hadoop.util.ToolRunner;
 
 import com.google.common.base.Charsets;
 
+/**
+ * This class is copied from apache/hadoop and modified by adding logic to
+ * support PravegaInputFormat
+ *
+ */
 public class WordMedian extends Configured implements Tool {
 
     private double median = 0;

--- a/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMedian.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMedian.java
@@ -37,6 +37,9 @@ import com.google.common.base.Charsets;
  * This class is copied from apache/hadoop and modified by adding logic to
  * support PravegaInputFormat
  *
+ * https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-examples
+ * /src/main/java/org/apache/hadoop/examples/WordMedian.java
+ *
  */
 public class WordMedian extends Configured implements Tool {
 

--- a/hadoop-examples/src/main/java/io/pravega/examples/spark/WordCount.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/spark/WordCount.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.examples.spark;
+
+import io.pravega.connectors.hadoop.EventKey;
+import io.pravega.connectors.hadoop.PravegaInputFormat;
+import io.pravega.examples.hadoop.TextSerializer;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.util.GenericOptionsParser;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import scala.Tuple2;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+
+public final class WordCount {
+    private static final Pattern SPACE = Pattern.compile(" ");
+
+    public static void main(String[] args) throws Exception {
+
+        Configuration conf = new Configuration();
+        GenericOptionsParser optionParser = new GenericOptionsParser(conf, args);
+        String[] remainingArgs = optionParser.getRemainingArgs();
+
+        if (remainingArgs.length != 3) {
+            System.err.println("Usage: WordCount <url> <scope> <stream>");
+            System.exit(2);
+        }
+
+        conf.setStrings(PravegaInputFormat.URI_STRING, remainingArgs[0]);
+        conf.setStrings(PravegaInputFormat.SCOPE_NAME, remainingArgs[1]);
+        conf.setStrings(PravegaInputFormat.STREAM_NAME, remainingArgs[2]);
+        conf.setStrings(PravegaInputFormat.DESERIALIZER, TextSerializer.class.getName());
+
+        JavaSparkContext sc = new JavaSparkContext(new SparkConf());
+
+        JavaPairRDD<EventKey, Text> lines = sc.newAPIHadoopRDD(conf, PravegaInputFormat.class, EventKey.class, Text.class);
+        JavaRDD<String> words = lines.map(x -> x._2).flatMap(s -> Arrays.asList(SPACE.split(s.toString())).iterator());
+        JavaPairRDD<String, Integer> ones = words.mapToPair(s -> new Tuple2<>(s, 1));
+        JavaPairRDD<String, Integer> counts = ones.reduceByKey((i1, i2) -> i1 + i2);
+
+        System.out.println("RESULT :" + counts.collect());
+    }
+}

--- a/hadoop-examples/src/main/java/io/pravega/examples/spark/WordCount.java
+++ b/hadoop-examples/src/main/java/io/pravega/examples/spark/WordCount.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.examples.spark;


### PR DESCRIPTION
Signed-off-by: Bo Yang <b.yang@emc.com>

This PR adds a number of examples that exercise the Pravega Input Format implementation in the hadoop connectors project.

The files below are copied from apache hadoop and modfied a little bit to support Pravega
hadoop-examples/src/main/java/io/pravega/examples/hadoop/ExampleDriver.java
hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomTextWriter.java
hadoop-examples/src/main/java/io/pravega/examples/hadoop/RandomWriter.java
hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordCount.java
hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMean.java
hadoop-examples/src/main/java/io/pravega/examples/hadoop/WordMedian.java
