### PR TITLE
[issue 72] Flink example - exactly once

### DIFF
--- a/flink-examples/README.md
+++ b/flink-examples/README.md
@@ -31,3 +31,8 @@ This example demonstrates how to use the Pravega Flink Connectors to write data 
 from an external network stream into a Pravega stream and read the data from the Pravega stream.
 See [Flink Word Count Sample](doc/flink-wordcount/README.md) for instructions.
 
+
+## Exactly Once Sample
+
+This sample demonstrates Pravega EXACTLY_ONCE feature in conjuction with Flink checkpointing and exactly-once mode.
+See [Exactly Once Sample](doc/exactly-once/README.md) for instructions.

--- a/flink-examples/build.gradle
+++ b/flink-examples/build.gradle
@@ -54,6 +54,20 @@ task scriptWordCountReader(type: CreateStartScripts) {
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
+task scriptExactlyOnceWriter(type: CreateStartScripts) {
+    outputDir = file('build/scripts')
+    mainClassName = 'io.pravega.examples.flink.primer.process.ExactlyOnceWriter'
+    applicationName = 'exactlyOnceWriter'
+    classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
+}
+
+task scriptExactlyOnceChecker(type: CreateStartScripts) {
+    outputDir = file('build/scripts')
+    mainClassName = 'io.pravega.examples.flink.primer.process.ExactlyOnceChecker'
+    applicationName = 'exactlyOnceChecker'
+    classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
+}
+
 distributions {
     main {
         baseName = archivesBaseName
@@ -67,6 +81,8 @@ distributions {
             into('bin') {
                 from project.scriptWordCountWriter
                 from project.scriptWordCountReader
+                from project.scriptExactlyOnceWriter
+                from project.scriptExactlyOnceChecker
             }
         }
     }

--- a/flink-examples/doc/exactly-once/README.md
+++ b/flink-examples/doc/exactly-once/README.md
@@ -1,0 +1,91 @@
+# Exactly Once Example
+
+This example demonstrates how Pravega EXACTLY_ONCE mode works in conjection with Flink checkpointing and exactly-once mode. More information on Pravega EXACTLY_ONCE semantics can be found at [here](http://pravega.io/docs/latest/key-features/#exactly-once-semantics).
+
+The example consists of two applications, a writer and a checker.
+
+```
+$ cd flink-examples/build/install/pravega-flink-examples
+$ bin/exactlyOnceChecker  [--controller tcp://localhost:9090] [--scope examples] [--stream mystream]
+$ bin/exactlyOnceWriter   [--controller tcp://localhost:9090] [--scope examples] [--stream mystream] [--num-events 50] [--exactlyonce true]
+```
+
+The writer application generates a set of "integer" events and introduces an artificial exception to 
+simulate transaction failure. It takes checkpoints periodically. It is configured to restore 
+from the latest Flink checkpoint in case of failures.
+For demo purpose, it also generates "start" and "end" events for the checker to detect duplicate events.
+
+Start the ExactlyOnceChecker app in one window. Come back to the window to observe the output 
+after running the writer app.
+
+```
+$ bin/exactlyOnceChecker --scope examples --stream mystream --controller tcp://localhost:9090
+```
+
+
+In another window, start the ExactlyOnceWriter with EXACTLY_ONCE mode set to false.
+This is to demonstrate what happens when Pravega EXACTLY_ONCE mode not enabled 
+
+```
+$ bin/exactlyOnceWriter --controller tcp://localhost:9090 --scope examples --stream mystream --exactlyonce false
+```
+
+Snippets of output shown below:
+
+```
+......
+
+Start checkpointing at position 16
+Complete checkpointing at position 16
+Artificial failure at position 26
+05/02/2018 17:02:02	Source: Custom Source -> Map(1/1) switched to FAILED 
+io.pravega.examples.flink.primer.util.FailingMapper$IntentionalException: artificial failure
+
+......
+
+Restore from checkpoint at position 16
+Start checkpointing at position 50
+Complete checkpointing at position 50
+
+......
+
+```
+The app completes checkpointing at position 16, and in the meantime, continues to write to the 
+Pravega stream until it introduces an artificial exception to simulate transaction failure 
+at position 26. Upon the failure, the app restores from its last successful checkpoint 
+at position 16. Without the Pravega EXACTLY_ONCE enabled, it is likely that duplicate events, 
+from position 17 to 26, will be written to the Pravega stream. 
+
+And indeed, that's what checker app shows. Note that output of duplicate events may not necessarily 
+be within the checker start and end block. 
+
+```
+============== Checker starts ===============
+Duplicate event: 18
+Duplicate event: 20
+Duplicate event: 22
+Duplicate event: 24
+Duplicate event: 17
+Duplicate event: 19
+Duplicate event: 21
+Duplicate event: 23
+Found duplicates
+============== Checker ends  ===============
+```
+
+If you wish, run the writer app a few more times by specifying different values for --num-events option.
+The app will restore from different positions and the checker window should continue to show duplicate events. 
+
+Now run the ExactlyOnceWriter in EXACTLY_ONCE mode.
+
+```
+$ bin/exactlyOnceWriter --controller tcp://localhost:9090 --scope examples --stream mystream --num-events 50  --exactlyonce true
+```
+
+The output should look like the followings:
+
+```
+============== Checker starts ===============
+No duplicate found. EXACTLY_ONCE!
+============== Checker ends  ===============
+```

--- a/flink-examples/src/main/java/io/pravega/examples/flink/primer/datatype/Constants.java
+++ b/flink-examples/src/main/java/io/pravega/examples/flink/primer/datatype/Constants.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *   
+ */
+package io.pravega.examples.flink.primer.datatype;
+
+/**
+ * Defines a handful of constants shared by classes in this package.
+ *
+ */
+public class Constants {
+    public static final String SCOPE_PARAM = "scope";
+    public static final String DEFAULT_SCOPE = "examples";
+    public static final String STREAM_PARAM = "stream";
+    public static final String DEFAULT_STREAM = "mystream";
+    public static final String Default_URI_PARAM = "controller";
+    public static final String Default_URI = "tcp://localhost:9090";
+}

--- a/flink-examples/src/main/java/io/pravega/examples/flink/primer/datatype/IntegerEvent.java
+++ b/flink-examples/src/main/java/io/pravega/examples/flink/primer/datatype/IntegerEvent.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+package io.pravega.examples.flink.primer.datatype;
+
+import java.io.Serializable;
+
+/*
+ * WordCount event that contains the word and the summary count
+ */
+public class IntegerEvent implements Serializable {
+
+    public static final long start = -1;
+    public static final long end = -9999;
+
+    private long value;
+
+    public IntegerEvent() {}
+
+    public IntegerEvent(long value)
+    {
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    public void setValue(long value) {
+        this.value = value;
+    }
+
+    public boolean isStart() {
+        return value == start;
+    }
+
+    public boolean isEnd() {
+        return value == end;
+    }
+
+    @Override
+    public String toString() {
+        return "IntegerEvent: " + value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (value ^ (value >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(this==obj){
+            return true;
+        }
+        if(!(obj instanceof IntegerEvent)){
+            return false;
+        }
+        IntegerEvent event = (IntegerEvent) obj;
+        return  event.getValue() == value
+                ;
+    }
+
+}

--- a/flink-examples/src/main/java/io/pravega/examples/flink/primer/process/ExactlyOnceChecker.java
+++ b/flink-examples/src/main/java/io/pravega/examples/flink/primer/process/ExactlyOnceChecker.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package io.pravega.examples.flink.primer.process;
+
+import io.pravega.client.stream.Stream;
+import io.pravega.connectors.flink.FlinkPravegaReader;
+import io.pravega.connectors.flink.PravegaConfig;
+import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.examples.flink.Utils;
+import io.pravega.examples.flink.primer.datatype.Constants;
+import io.pravega.examples.flink.primer.datatype.IntegerEvent;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.*;
+
+/*
+ * Parameters
+ *     -stream <pravega_scope>/<pravega_stream>, e.g., myscope/stream1
+ *     -controller tcp://<controller_host>:<port>, e.g., tcp://localhost:9090
+ *
+ */
+public class ExactlyOnceChecker {
+
+    private static Set<IntegerEvent> checker = new HashSet<>();
+    private static List<IntegerEvent> duplicates = new ArrayList<IntegerEvent>();
+
+    // Logger initialization
+    private static final Logger LOG = LoggerFactory.getLogger(ExactlyOnceChecker.class);
+
+    public static void main(String[] args) throws Exception {
+        LOG.info("Starting ExactlyOnce checker ...");
+
+        // initialize the parameter utility tool in order to retrieve input parameters
+        ParameterTool params = ParameterTool.fromArgs(args);
+
+        PravegaConfig pravegaConfig = PravegaConfig
+                .fromParams(params)
+                .withControllerURI(URI.create(params.get(Constants.Default_URI_PARAM, Constants.Default_URI)))
+                .withDefaultScope(params.get(Constants.SCOPE_PARAM, Constants.DEFAULT_SCOPE));
+
+        // create the Pravega input stream (if necessary)
+        Stream stream = Utils.createStream(
+                pravegaConfig,
+                params.get(Constants.STREAM_PARAM, Constants.DEFAULT_STREAM));
+
+        // initialize Flink execution environment
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment
+                .getExecutionEnvironment()
+                .setParallelism(1);
+
+        // create the Pravega source to read a stream of text
+        FlinkPravegaReader<IntegerEvent> reader = FlinkPravegaReader.<IntegerEvent>builder()
+                .withPravegaConfig(pravegaConfig)
+                .forStream(stream)
+                .withDeserializationSchema(PravegaSerialization.deserializationFor(IntegerEvent.class))
+                .build();
+
+        DataStream<IntegerEvent> dataStream = env
+                .addSource(reader)
+                .setParallelism(1);
+
+        // create output stream to data read from Pravega
+        //dataStream.print();
+
+        DataStream<DuplicateEvent> duplicateStream = dataStream.flatMap(new FlatMapFunction<IntegerEvent, DuplicateEvent>() {
+            @Override
+            public void flatMap(IntegerEvent event, Collector<DuplicateEvent> out) throws Exception {
+
+                if (event.isStart()) {
+                    // clear checker when the beginning of stream marker arrives
+                    checker.clear();
+                    duplicates.clear();
+                    System.out.println("\n============== Checker starts ===============");
+                }
+                if (event.isEnd()) {
+                    if (duplicates.size() == 0) {
+                        System.out.println("No duplicate found. EXACTLY_ONCE!");
+                    } else {
+                        System.out.println("Found duplicates");
+                    }
+                    System.out.println("============== Checker ends  ===============\n");
+                }
+                if (checker.contains(event)) {
+                    duplicates.add(event);
+                    DuplicateEvent dup = new DuplicateEvent(event.getValue());
+                    System.out.println(dup);
+                    out.collect(dup);
+                } else {
+                    checker.add(event);
+                }
+            }
+        });
+
+        // create output sink to print duplicates
+        //duplicateStream.print();
+
+        // execute within the Flink environment
+        env.execute("ExactlyOnceChecker");
+
+        LOG.info("Ending ExactlyOnceChecker...");
+    }
+
+    private static class DuplicateEvent {
+       private long value;
+
+       DuplicateEvent(long value ) {
+           this.value = value;
+       }
+
+       @Override
+       public String toString() {
+           return "Duplicate event: " + this.value;
+       }
+    }
+
+}

--- a/flink-examples/src/main/java/io/pravega/examples/flink/primer/process/ExactlyOnceWriter.java
+++ b/flink-examples/src/main/java/io/pravega/examples/flink/primer/process/ExactlyOnceWriter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package io.pravega.examples.flink.primer.process;
+
+import io.pravega.client.stream.Stream;
+import io.pravega.connectors.flink.*;
+import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.examples.flink.Utils;
+import io.pravega.examples.flink.primer.datatype.IntegerEvent;
+import io.pravega.examples.flink.primer.datatype.Constants;
+import io.pravega.examples.flink.primer.source.ThrottledIntegerEventProducer;
+import io.pravega.examples.flink.primer.util.FailingMapper;
+ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+ import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+/*
+ * Parameters
+ *     -scope  Pravega scope
+ *     -stream Pravega stream
+ *     -controller tcp://<controller_host>:<port>, e.g., tcp://localhost:9090
+ *     -num-events <number of events to be generated>
+ *
+ */
+public class ExactlyOnceWriter {
+    private static final long checkpointIntervalMillis = 100;
+    private static final Time txnTimeoutMillis = Time.milliseconds(30 * 1000);
+    private static final Time txnGracePeriodMillis = Time.milliseconds(30 * 1000);
+    private static final int defaultNumEvents = 50;
+
+    // read data from the time when the program starts
+    //private static final long readStartTimeMillis = Instant.now().toEpochMilli();
+
+    // Logger initialization
+    private static final Logger LOG = LoggerFactory.getLogger(ExactlyOnceWriter.class);
+
+    public static void main(String[] args) throws Exception {
+        LOG.info("Starting ExactlyOnce checker ...");
+
+        // initialize the parameter utility tool in order to retrieve input parameters
+        ParameterTool params = ParameterTool.fromArgs(args);
+
+        boolean exactlyOnce = Boolean.parseBoolean(params.get("exactlyonce", "true"));
+        int numEvents = Integer.parseInt(params.get("num-events", String.valueOf(defaultNumEvents)));
+
+        PravegaConfig pravegaConfig = PravegaConfig
+                .fromParams(params)
+                .withControllerURI(URI.create(params.get(Constants.Default_URI_PARAM, Constants.Default_URI)))
+                .withDefaultScope(params.get(Constants.SCOPE_PARAM, Constants.DEFAULT_SCOPE));
+
+        // create the Pravega input stream (if necessary)
+        Stream stream = Utils.createStream(
+                pravegaConfig,
+                params.get(Constants.STREAM_PARAM, Constants.DEFAULT_STREAM));
+
+        // initialize Flink execution environment
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment()
+                .enableCheckpointing(checkpointIntervalMillis, CheckpointingMode.EXACTLY_ONCE)
+                .setParallelism(1);
+
+        // Restart flink job from last checkpoint once.
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0L));
+
+
+        // create the Pravega sink to write a stream of text
+
+        FlinkPravegaWriter<IntegerEvent> writer = FlinkPravegaWriter.<IntegerEvent>builder()
+                .withPravegaConfig(pravegaConfig)
+                .forStream(stream)
+                .withEventRouter( new EventRouter())
+                .withTxnTimeout(txnTimeoutMillis)
+                .withTxnGracePeriod(txnGracePeriodMillis)
+                .withWriterMode( exactlyOnce ? PravegaWriterMode.EXACTLY_ONCE : PravegaWriterMode.ATLEAST_ONCE )
+                .withSerializationSchema(PravegaSerialization.serializationFor(IntegerEvent.class))
+                .build();
+
+        env
+            .addSource(new ThrottledIntegerEventProducer(numEvents))
+            .map(new FailingMapper<>(numEvents /2 ))  // simulate failure
+            .addSink(writer)
+            .setParallelism(2);
+
+        // execute within the Flink environment
+        env.execute("ExactlyOnce");
+
+
+        LOG.info("Ending ExactlyOnce...");
+    }
+
+    public static class EventRouter implements PravegaEventRouter<IntegerEvent> {
+        @Override
+        public String getRoutingKey(IntegerEvent event) {
+            return "fixedkey";
+        }
+    }
+
+}

--- a/flink-examples/src/main/java/io/pravega/examples/flink/primer/process/ExactlyOnceWriter.java
+++ b/flink-examples/src/main/java/io/pravega/examples/flink/primer/process/ExactlyOnceWriter.java
@@ -55,7 +55,7 @@ public class ExactlyOnceWriter {
         ParameterTool params = ParameterTool.fromArgs(args);
 
         boolean exactlyOnce = Boolean.parseBoolean(params.get("exactlyonce", "true"));
-        int numEvents = Integer.parseInt(params.get("num-events", String.valueOf(defaultNumEvents)));
+        int numEvents = params.getInt("num-events", defaultNumEvents);
 
         PravegaConfig pravegaConfig = PravegaConfig
                 .fromParams(params)

--- a/flink-examples/src/main/java/io/pravega/examples/flink/primer/source/ThrottledIntegerEventProducer.java
+++ b/flink-examples/src/main/java/io/pravega/examples/flink/primer/source/ThrottledIntegerEventProducer.java
@@ -1,0 +1,208 @@
+
+/*
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+package io.pravega.examples.flink.primer.source;
+
+
+import io.pravega.examples.flink.primer.datatype.IntegerEvent;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializableObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ThrottledIntegerEventProducer
+        extends RichParallelSourceFunction<IntegerEvent>
+        implements ListCheckpointed<Long>, CheckpointListener {
+
+
+    private static final Logger LOG = LoggerFactory.getLogger(ThrottledIntegerEventProducer.class);
+
+    /**
+     * Blocker when the generator needs to wait for the checkpoint to happen.
+     * Eager initialization means it must be serializable (pick any serializable type)
+     */
+    private final Object blocker = new SerializableObject();
+
+
+    // The total number of events to generate
+    private final int numEventsTotal;
+
+    // The
+    private final int latestPosForCheckpoint;
+
+    // The current position in the sequence of numbers
+    private long currentPosition = -1;
+
+    // The last checkpoint triggered;
+    private long lastCheckpointTriggered;
+
+    // The last checkpoint confirmed.
+    private long lastCheckpointConfirmed;
+
+    // The position of last checkpoint
+    private long checkpointPosition = -1;
+
+    // Set to true after restore
+    private boolean restored = false;
+
+
+    /**
+     * Flag to cancel the source. Must be volatile, because modified asynchronously
+     */
+    private volatile boolean running = true;
+
+
+    public ThrottledIntegerEventProducer(final int numEventsTotal)
+    {
+        this(numEventsTotal, numEventsTotal / 3);
+    }
+
+
+    public ThrottledIntegerEventProducer(final int numEventsTotal, final int latestPosForCheckpoint) {
+        Preconditions.checkArgument(numEventsTotal > 0);
+        Preconditions.checkArgument(latestPosForCheckpoint >= 0 && latestPosForCheckpoint < numEventsTotal);
+
+        this.numEventsTotal = numEventsTotal;
+        this.latestPosForCheckpoint = latestPosForCheckpoint;
+    }
+
+    @Override
+    public String toString() {
+        return "numEventsTotal = " + numEventsTotal + "," +
+                "latestPosForCheckpoint = " + latestPosForCheckpoint + "," +
+                "snapshotPosition = " + checkpointPosition + "," +
+                "currentPosition = " + currentPosition + "," +
+                "lastCheckpointTriggered = " + lastCheckpointTriggered + "," +
+                "lastCheckpointConfirmed = " + lastCheckpointConfirmed;
+    }
+
+    /**
+     * @param ctx The context to emit elements to and for accessing locks.
+     */
+    @Override
+    public void run(SourceContext<IntegerEvent> ctx) throws Exception {
+
+
+        // each source subtask emits only the numbers where (num % parallelism == subtask_index)
+        final int stepSize = getRuntimeContext().getNumberOfParallelSubtasks();
+        long current = this.currentPosition >= 0 ? this.currentPosition : getRuntimeContext().getIndexOfThisSubtask();
+
+        synchronized (ctx.getCheckpointLock()) {
+            if (!restored) {
+                // beginning of stream
+                ctx.collect(new IntegerEvent(IntegerEvent.start));
+            }
+        }
+
+        while (this.running && current < this.numEventsTotal) {
+
+            // throttle if no checkpoint happened so far
+            if (this.lastCheckpointConfirmed < 1) {
+                if (current < this.latestPosForCheckpoint) {
+                    Thread.sleep(5);
+                } else {
+                    synchronized (blocker) {
+                        while (this.running && this.lastCheckpointConfirmed < 1 ) {
+                            blocker.wait();
+                        }
+                    }
+                }
+            }
+
+            // emit the next event
+            current += stepSize;
+            synchronized (ctx.getCheckpointLock()) {
+                //System.out.println("Emitting: current = " + current + ", " + toString());
+                ctx.collect(new IntegerEvent(current));
+                this.currentPosition = current;
+            }
+        }
+
+        synchronized (ctx.getCheckpointLock()) {
+            if (restored) {
+                // end of stream
+                ctx.collect(new IntegerEvent(IntegerEvent.end));
+            }
+        }
+
+        // after we are done, we need to wait for two more checkpoint to complete
+        // before finishing the program - that is to be on the safe side that
+        // the sink also got the "commit" notification for all relevant checkpoints
+        // and committed the data to pravega
+
+        // note: this indicates that to handle finite jobs with 2PC outputs more
+        // easily, we need a primitive like "finish-with-checkpoint" in Flink
+
+        final long lastCheckpoint;
+        synchronized (ctx.getCheckpointLock()) {
+            lastCheckpoint = this.lastCheckpointTriggered;
+        }
+
+        synchronized (this.blocker) {
+            while (this.lastCheckpointConfirmed <= lastCheckpoint + 1) {
+                this.blocker.wait();
+            }
+        }
+    }
+
+    /**
+     * Cancels the source. Most sources will have a while loop inside the
+     * {@link #run(SourceContext)} method. The implementation needs to ensure that the
+     * source will break out of that loop after this method is called.
+     * <p>
+     */
+    @Override
+    public void cancel() {
+        running = false;
+    }
+
+    @Override
+    public List<Long> snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
+        this.lastCheckpointTriggered = checkpointId;
+        this.checkpointPosition = this.currentPosition;
+        System.out.println("Start checkpointing at position " + this.currentPosition);
+        return Collections.singletonList(this.currentPosition);
+    }
+
+    @Override
+    public void restoreState(List<Long> state) throws Exception {
+        this.currentPosition = state.get(0);
+
+        // at least one checkpoint must have happened so far
+        this.lastCheckpointTriggered = 1L;
+        this.lastCheckpointConfirmed = 1L;
+        this.restored = true;
+        System.out.println("Restore from checkpoint at position " + this.currentPosition);
+    }
+    /*
+     * Simulate data a client sent to apache web server.
+     */
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+
+        synchronized (blocker) {
+            if (checkpointPosition > -1) {
+                // confirm only after a "real" checkpoint, i.e., position is greater than -1.
+                this.lastCheckpointConfirmed = checkpointId;
+                System.out.println("Complete checkpointing at position " + this.checkpointPosition);
+            }
+            blocker.notifyAll();
+        }
+    }
+
+}

--- a/flink-examples/src/main/java/io/pravega/examples/flink/primer/source/ThrottledIntegerEventProducer.java
+++ b/flink-examples/src/main/java/io/pravega/examples/flink/primer/source/ThrottledIntegerEventProducer.java
@@ -29,7 +29,6 @@ public class ThrottledIntegerEventProducer
         extends RichParallelSourceFunction<IntegerEvent>
         implements ListCheckpointed<Long>, CheckpointListener {
 
-
     private static final Logger LOG = LoggerFactory.getLogger(ThrottledIntegerEventProducer.class);
 
     /**
@@ -38,11 +37,10 @@ public class ThrottledIntegerEventProducer
      */
     private final Object blocker = new SerializableObject();
 
-
     // The total number of events to generate
     private final int numEventsTotal;
 
-    // The
+    // The position to have at least one checkpoint
     private final int latestPosForCheckpoint;
 
     // The current position in the sequence of numbers
@@ -60,18 +58,13 @@ public class ThrottledIntegerEventProducer
     // Set to true after restore
     private boolean restored = false;
 
-
-    /**
-     * Flag to cancel the source. Must be volatile, because modified asynchronously
-     */
+    //Flag to cancel the source. Must be volatile, because modified asynchronously
     private volatile boolean running = true;
-
 
     public ThrottledIntegerEventProducer(final int numEventsTotal)
     {
         this(numEventsTotal, numEventsTotal / 3);
     }
-
 
     public ThrottledIntegerEventProducer(final int numEventsTotal, final int latestPosForCheckpoint) {
         Preconditions.checkArgument(numEventsTotal > 0);
@@ -189,9 +182,7 @@ public class ThrottledIntegerEventProducer
         this.restored = true;
         System.out.println("Restore from checkpoint at position " + this.currentPosition);
     }
-    /*
-     * Simulate data a client sent to apache web server.
-     */
+
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
 

--- a/flink-examples/src/main/java/io/pravega/examples/flink/primer/util/FailingMapper.java
+++ b/flink-examples/src/main/java/io/pravega/examples/flink/primer/util/FailingMapper.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2018 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.examples.flink.primer.util;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+
+import java.util.List;
+
+/**
+ * An identity mapper that throws an exception at a specified element.
+ * The exception is only thrown during the first execution, prior to the first recovery.
+ * <p>
+ * <p>The function also fails, if the program terminates cleanly before the
+ * function would throw an exception. That way, it guards against the case
+ * where a failure is never triggered (for example because of a too high value for
+ * the number of elements to pass before failing).
+ */
+public class FailingMapper<T> implements MapFunction<T, T>, ListCheckpointed<Integer> {
+
+    /**
+     * The number of elements to wait for, before failing
+     */
+    private final int failAtElement;
+
+    private int elementCount;
+    private boolean restored;
+
+    /**
+     * Creates a mapper that fails after processing the given number of elements.
+     *
+     * @param failAtElement The number of elements to wait for, before failing.
+     */
+    public FailingMapper(int failAtElement) {
+        this.failAtElement = failAtElement;
+    }
+
+    @Override
+    public T map(T element) throws Exception {
+        if (!restored && ++elementCount > failAtElement) {
+            System.out.println("Artificial failure at position " + elementCount);
+            throw new IntentionalException("artificial failure");
+        }
+
+        return element;
+    }
+
+    @Override
+    public String toString() {
+        return "FAILING MAPPER: elementCount = " + elementCount + "," +
+                "failedAtElemtn = " + failAtElement + "," +
+                "restored = " + restored;
+    }
+
+    @Override
+    public void restoreState(List<Integer> list) throws Exception {
+        restored = true;
+    }
+
+    @Override
+    public List<Integer> snapshotState(long l, long l1) throws Exception {
+        return null;
+    }
+
+    public static class IntentionalException extends Exception {
+        public IntentionalException(String message) {
+            super(message);
+        }
+    }
+}


### PR DESCRIPTION
**Change log description**
- This PR adds a Flink example job to demonstrate Pravega EXACTLY_ONCE feature. 
- Updated to use the builder API.

**Purpose of the change**
Fixes #72 

**What the code does**
Flink job to demo Pravega EXACTLY_ONCE feature

**How to verify it**
See details in [README](https://github.com/pravega/pravega-samples/tree/flink-issue-72-take2/flink-examples/doc/exactly-once)
 