### PR TITLE
Issue 84: Channel not shutdown correctly in TurbineHeatSensor sample

### DIFF
--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -116,18 +116,18 @@ public class TurbineHeatSensor {
         Instant startEventTime = Instant.EPOCH.plus(8, ChronoUnit.HOURS); // sunrise
 
 	    for (int i = 0; i < producerCount; i++) {
-	    	double baseTemperature = locations[i % locations.length].length() * 10;
-	    	TemperatureSensor sensor =
+		    double baseTemperature = locations[i % locations.length].length() * 10;
+		    TemperatureSensor sensor =
 				    new TemperatureSensor(i, locations[i % locations.length], baseTemperature, 20, startEventTime);
-	    	TemperatureSensors worker;
-	    	if (isTransaction) {
-	    		worker = new TransactionTemperatureSensors(sensor, eventsPerSec, runtimeSec,
+		    TemperatureSensors worker;
+		    if (isTransaction) {
+			    worker = new TransactionTemperatureSensors(sensor, eventsPerSec, runtimeSec,
 					    isTransaction, clientFactory);
-	    	} else {
-	    		worker = new TemperatureSensors(sensor, eventsPerSec, runtimeSec,
+		    } else {
+			    worker = new TemperatureSensors(sensor, eventsPerSec, runtimeSec,
 					    isTransaction, clientFactory);
-	    	}
-	    	executor.execute(worker);
+		    }
+		    executor.execute(worker);
 	    }
 
         executor.shutdown();

--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -83,8 +83,8 @@ public class TurbineHeatSensor {
         // Initialize executor
         ExecutorService executor = Executors.newFixedThreadPool(producerCount + 10);
 
-		URI controllerUri;
-		ClientFactory clientFactory;
+        URI controllerUri;
+        ClientFactory clientFactory;
         try {
             controllerUri = new URI(TurbineHeatSensor.controllerUri);
             clientFactory = ClientFactory.withScope(scopeName, controllerUri);
@@ -115,20 +115,20 @@ public class TurbineHeatSensor {
         /* Create producerCount number of threads to simulate sensors. */
         Instant startEventTime = Instant.EPOCH.plus(8, ChronoUnit.HOURS); // sunrise
 
-		for (int i = 0; i < producerCount; i++) {
-			double baseTemperature = locations[i % locations.length].length() * 10;
-			TemperatureSensor sensor =
-					new TemperatureSensor(i, locations[i % locations.length], baseTemperature, 20, startEventTime);
-			TemperatureSensors worker;
-			if (isTransaction) {
-				worker = new TransactionTemperatureSensors(sensor, eventsPerSec, runtimeSec,
-						isTransaction, clientFactory);
-			} else {
-				worker = new TemperatureSensors(sensor, eventsPerSec, runtimeSec,
-						isTransaction, clientFactory);
-			}
-			executor.execute(worker);
-		}
+	    for (int i = 0; i < producerCount; i++) {
+	    	double baseTemperature = locations[i % locations.length].length() * 10;
+	    	TemperatureSensor sensor =
+				    new TemperatureSensor(i, locations[i % locations.length], baseTemperature, 20, startEventTime);
+	    	TemperatureSensors worker;
+	    	if (isTransaction) {
+	    		worker = new TransactionTemperatureSensors(sensor, eventsPerSec, runtimeSec,
+					    isTransaction, clientFactory);
+	    	} else {
+	    		worker = new TemperatureSensors(sensor, eventsPerSec, runtimeSec,
+					    isTransaction, clientFactory);
+	    	}
+	    	executor.execute(worker);
+	    }
 
         executor.shutdown();
         // Wait until all threads are finished.
@@ -422,7 +422,7 @@ public class TurbineHeatSensor {
     private static class SensorReader implements Runnable {
 
         private final JavaSerializer<String> SERIALIZER = new JavaSerializer<>();
-		final EventStreamReader<String> reader;
+        final EventStreamReader<String> reader;
         private int totalEvents;
 
         public SensorReader(int totalEvents, ClientFactory clientFactory) {

--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -142,6 +142,7 @@ public class TurbineHeatSensor {
         if ( !onlyWrite ) {
             consumeStats.printTotal();
         }
+        clientFactory.close();
 //        ZipKinTracer.getTracer().close();
         System.exit(0);
     }
@@ -292,6 +293,7 @@ public class TurbineHeatSensor {
         private final int eventsPerSec;
         private final int secondsToRun;
         private final boolean isTransaction;
+        private final ClientFactory factory;
 
         TemperatureSensors(TemperatureSensor sensor, int eventsPerSec, int secondsToRun, boolean isTransaction,
                            ClientFactory factory) {
@@ -299,6 +301,7 @@ public class TurbineHeatSensor {
             this.eventsPerSec = eventsPerSec;
             this.secondsToRun = secondsToRun;
             this.isTransaction = isTransaction;
+            this.factory = factory;
 
             EventWriterConfig eventWriterConfig =  EventWriterConfig.builder()
                     .transactionTimeoutTime(DEFAULT_TXN_TIMEOUT_MS)
@@ -386,6 +389,7 @@ public class TurbineHeatSensor {
             } catch (InterruptedException | ExecutionException e ) {
                 e.printStackTrace();
             }
+            factory.close();
         }
 
         @Override

--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -381,8 +381,7 @@ public class TurbineHeatSensor {
                     System.exit(1);
                 }
             }
-            producer.flush();
-            //producer.close();
+            producer.close();
             try {
                 //Wait for the last packet to get acked
                 retFuture.get();

--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -114,21 +114,20 @@ public class TurbineHeatSensor {
         }
         /* Create producerCount number of threads to simulate sensors. */
         Instant startEventTime = Instant.EPOCH.plus(8, ChronoUnit.HOURS); // sunrise
-
-	    for (int i = 0; i < producerCount; i++) {
-		    double baseTemperature = locations[i % locations.length].length() * 10;
-		    TemperatureSensor sensor =
-				    new TemperatureSensor(i, locations[i % locations.length], baseTemperature, 20, startEventTime);
-		    TemperatureSensors worker;
-		    if (isTransaction) {
-			    worker = new TransactionTemperatureSensors(sensor, eventsPerSec, runtimeSec,
-					    isTransaction, clientFactory);
-		    } else {
-			    worker = new TemperatureSensors(sensor, eventsPerSec, runtimeSec,
-					    isTransaction, clientFactory);
-		    }
-		    executor.execute(worker);
-	    }
+        for (int i = 0; i < producerCount; i++) {
+            double baseTemperature = locations[i % locations.length].length() * 10;
+            TemperatureSensor sensor =
+                    new TemperatureSensor(i, locations[i % locations.length], baseTemperature, 20, startEventTime);
+            TemperatureSensors worker;
+            if ( isTransaction ) {
+                worker = new TransactionTemperatureSensors(sensor, eventsPerSec, runtimeSec,
+                        isTransaction, clientFactory);
+            } else {
+                worker = new TemperatureSensors(sensor, eventsPerSec, runtimeSec,
+                        isTransaction, clientFactory);
+            }
+            executor.execute(worker);
+        }
 
         executor.shutdown();
         // Wait until all threads are finished.

--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -303,7 +303,7 @@ public class TurbineHeatSensor {
             EventWriterConfig eventWriterConfig =  EventWriterConfig.builder()
                     .transactionTimeoutTime(DEFAULT_TXN_TIMEOUT_MS)
                     .build();
-            this.producer = clientFactory.createEventWriter(streamName, SERIALIZER, eventWriterConfig);
+            this.producer = factory.createEventWriter(streamName, SERIALIZER, eventWriterConfig);
 
         }
 


### PR DESCRIPTION
**Change log description**
Minor fix in `TurbineHeatSensor.java` regarding the use of client factories while creating writers. Note that this PR specifically targets to avoid `java.lang.RuntimeException: ManagedChannel allocation site` exception to be thrown (e.g., the app may throw other exceptions that will be addressed separately).  

**Purpose of the change**
Fixes #84.

**What the code does**
The constructor of `TemperatureSensors` receives by parameter a client factory to create event writers. However, it was creating writers via a global static client factory, which was in turn shared to create readers as well. Creating readers/writers carelessly, jointly with the fact that resources are not correctly closed, could be the cause for the closing channel exception to be thrown. In this fix, we replaced the use of the global static client factory by the one passed by parameter to create writers. While this was enough to avoid the exception to occur, we also decided to close both client factories and writers for the sake of correctness.

**How to verify it**
Execute the `turbineHeatSensor` application and verify that the exception mentioned in the issue does not appear in the console.