### PR TITLE
Issue 85: turbineSensor throws occasional NPE

### DIFF
--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -438,13 +438,16 @@ public class TurbineHeatSensor {
                 do {
                     try {
                         final EventRead<String> result = reader.readNextEvent(0);
-                        produceStats.runAndRecordTime(() -> {
-                            return CompletableFuture.completedFuture(null);
-                        }, Long.parseLong(result.getEvent().split(",")[0]), 100);
+                        if (result.getEvent() != null) {
+                            consumeStats.runAndRecordTime(() -> {
+                                return CompletableFuture.completedFuture(null);
+                            }, Long.parseLong(result.getEvent().split(",")[0]), 100);
+                            totalEvents--;
+                        }
                     } catch (ReinitializationRequiredException e) {
                         e.printStackTrace();
                     }
-                } while ( totalEvents-- > 0 );
+                } while (totalEvents > 0);
             }
             finally {
                 reader.close();


### PR DESCRIPTION
**Change log description**
Fix in `TrubineHeatSensor.java` for avoiding the application to throw `NullPointerException`. Note that this PR only targets this specific problem (i.e., other exceptions or problems will be treated separately).

**Purpose of the change**
Fixes #85.

**What the code does**
The reader (`SensorReader`) is incorrectly interacting with `produceStats` instead of with `consumeStats`. Moreover, the read loop of this class parses read events without checking for null events (e.g., after timeout). The fix consists of replacing reader interactions from `produceStats` to `consumeStats` as well as to check for a null read event before executing the parse logic.

**How to verify it**
Execute the application and verify that it does not throws NPE.
