### PR TITLE
Issue 87: Problem finding logback.xml

### DIFF
--- a/pravega-client-examples/build.gradle
+++ b/pravega-client-examples/build.gradle
@@ -41,7 +41,7 @@ task scriptHelloWorldWriter(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.gettingstarted.HelloWorldWriter'
     applicationName = 'helloWorldWriter'
-    defaultJvmOpts = ["-Dlogback.configurationFile=file:conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -49,7 +49,7 @@ task scriptHelloWorldReader(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.gettingstarted.HelloWorldReader'
     applicationName = 'helloWorldReader'
-    defaultJvmOpts = ["-Dlogback.configurationFile=file:conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -73,7 +73,7 @@ task scriptConsoleWriter(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.consolerw.ConsoleWriter'
     applicationName = 'consoleWriter'
-    defaultJvmOpts = ["-Dlogback.configurationFile=file:conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -81,7 +81,7 @@ task scriptConsoleReader(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.consolerw.ConsoleReader'
     applicationName = 'consoleReader'
-    defaultJvmOpts = ["-Dlogback.configurationFile=file:conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -97,7 +97,7 @@ task scriptSharedConfigCli(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.statesynchronizer.SharedConfigCli'
     applicationName = 'sharedConfigCli'
-    defaultJvmOpts = ["-Dlogback.configurationFile=file:conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -105,7 +105,7 @@ task scriptNoopReader(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.noop.NoopReader'
     applicationName = 'noopReader'
-    defaultJvmOpts = ["-Dlogback.configurationFile=file:conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -121,7 +121,7 @@ task scriptStreamCutsCli(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.streamcuts.StreamCutsCli'
     applicationName = 'streamCutsCli'
-    defaultJvmOpts = ["-Dlogback.configurationFile=file:conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 

--- a/pravega-client-examples/build.gradle
+++ b/pravega-client-examples/build.gradle
@@ -41,7 +41,7 @@ task scriptHelloWorldWriter(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.gettingstarted.HelloWorldWriter'
     applicationName = 'helloWorldWriter'
-    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -49,31 +49,15 @@ task scriptHelloWorldReader(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.gettingstarted.HelloWorldReader'
     applicationName = 'helloWorldReader'
-    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
-}
-
-task startHelloWorldWriter(type: JavaExec) {
-    main = "io.pravega.example.gettingstarted.HelloWorldWriter"
-    classpath = sourceSets.main.runtimeClasspath
-    if(System.getProperty("exec.args") != null) {
-        args System.getProperty("exec.args").split()
-    }
-}
-
-task startHelloWorldReader(type: JavaExec) {
-    main = "io.pravega.example.gettingstarted.HelloWorldReader"
-    classpath = sourceSets.main.runtimeClasspath
-    if(System.getProperty("exec.args") != null) {
-        args System.getProperty("exec.args").split()
-    }
 }
 
 task scriptConsoleWriter(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.consolerw.ConsoleWriter'
     applicationName = 'consoleWriter'
-    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -81,23 +65,15 @@ task scriptConsoleReader(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.consolerw.ConsoleReader'
     applicationName = 'consoleReader'
-    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
-}
-
-task startConsoleReader(type: JavaExec) {
-    main = "io.pravega.example.consolerw.ConsoleReader"
-    classpath = sourceSets.main.runtimeClasspath
-    if(System.getProperty("exec.args") != null) {
-        args System.getProperty("exec.args").split()
-    }
 }
 
 task scriptSharedConfigCli(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.statesynchronizer.SharedConfigCli'
     applicationName = 'sharedConfigCli'
-    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 
@@ -105,32 +81,16 @@ task scriptNoopReader(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.noop.NoopReader'
     applicationName = 'noopReader'
-    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
-}
-
-task startNoopReader(type: JavaExec) {
-    main = "io.pravega.example.noop.NoopReader"
-    classpath = sourceSets.main.runtimeClasspath
-    if(System.getProperty("exec.args") != null) {
-        args System.getProperty("exec.args").split()
-    }
 }
 
 task scriptStreamCutsCli(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.example.streamcuts.StreamCutsCli'
     applicationName = 'streamCutsCli'
-    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
-}
-
-task startStreamCutsCli(type: JavaExec) {
-    main = "io.pravega.example.streamcuts.StreamCutsCli"
-    classpath = sourceSets.main.runtimeClasspath
-    if(System.getProperty("exec.args") != null) {
-        args System.getProperty("exec.args").split()
-    }
 }
 
 distributions {

--- a/pravega-client-examples/src/main/java/io/pravega/example/consolerw/ConsoleReader.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/consolerw/ConsoleReader.java
@@ -242,7 +242,6 @@ public class ConsoleReader implements Closeable {
             do {
                 event = reader.readNextEvent(1000);
                 if (event.getEvent() != null) {
-                    // TODO: Problem finding logback.xml in Pravega example applications (Issue #87).
                     output("[StreamCut read from/up to] Read event: %s%n", event.getEvent());
                     log.info("[StreamCut read from/up to] Read event: {}.", event.getEvent());
                 }
@@ -368,7 +367,6 @@ class BackgroundReader implements Closeable, Runnable {
             do {
                 event = reader.readNextEvent(READER_TIMEOUT_MS);
                 if (event.getEvent() != null) {
-                    // TODO: Problem finding logback.xml in Pravega example applications (Issue #87).
                     System.out.println("[BackgroundReader] Read event: " + event.getEvent());
                     log.info("[BackgroundReader] Read event: {}.", event.getEvent());
                 }

--- a/scenarios/turbine-heat-sensor/build.gradle
+++ b/scenarios/turbine-heat-sensor/build.gradle
@@ -39,7 +39,7 @@ task scriptTurbineSensor(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.turbineheatsensor.TurbineHeatSensor'
     applicationName = 'turbineSensor'
-    defaultJvmOpts = ["-Dlogback.configurationFile=file:conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
 

--- a/scenarios/turbine-heat-sensor/build.gradle
+++ b/scenarios/turbine-heat-sensor/build.gradle
@@ -39,18 +39,9 @@ task scriptTurbineSensor(type: CreateStartScripts) {
     outputDir = file('build/scripts')
     mainClassName = 'io.pravega.turbineheatsensor.TurbineHeatSensor'
     applicationName = 'turbineSensor'
-    defaultJvmOpts = ["-Dlogback.configurationFile=conf/logback.xml"]
+    defaultJvmOpts = ["-Dlogback.configurationFile=logback.xml"]
     classpath = files(jar.archivePath) + sourceSets.main.runtimeClasspath
 }
-
-task startTurbineSensor(type: JavaExec) {
-    main = "io.pravega.turbineheatsensor.TurbineHeatSensor"
-    classpath = sourceSets.main.runtimeClasspath
-    if(System.getProperty("exec.args") != null) {
-        args System.getProperty("exec.args").split()
-    }
-}
-
 
 distributions {
     main {


### PR DESCRIPTION
**Change log description**
Changed the `build.gradle` file of `pravega-client-examples` and `scenarios/turbine-heat-sensor` to correctly point to the packaged `logback.xml` file.

**Purpose of the change**
Fixes #87.

**What the code does**
The code just deletes the `file:` prefix in `build.gradle` which was apparently preventing the execution script to find the `logback.xml` file. This PR also deletes two `TODOs` related to this issue in `ConsoleReader.java`: as before, we output each read event to both to the user via console and to the log. Otherwise, showing read events to the user would require to write in the console log entries for `INFO` level, which is excessive and may be confusing for the user.

**How to verify it**
Build `pravega-client-examples` and `scenarios/turbine-heat-sensor` and execute the applications. There should not be any exception as the one reported in the issue.