### PR TITLE
Issue 116: Deleted upload instructions in Flink connector samples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,21 +43,4 @@ subprojects {
         group "io.pravega"
         version samplesVersion
     }
-
-    remotes {
-        dcos {
-            host = dcosAddress
-            user = 'centos'
-            agent = true
-        }
-    }
-    ssh.settings {
-        knownHosts = allowAnyHosts
-    }
-
-    afterEvaluate {
-        task upload(type: Exec, dependsOn: installDist) {
-            commandLine 'rsync', '-az', project.installDist.destinationDir, "${remotes.dcos.user}@${remotes.dcos.host}:~"
-        }
-    }
 }

--- a/flink-connector-examples/README.md
+++ b/flink-connector-examples/README.md
@@ -8,8 +8,7 @@ system for Apache Flink.
 3. Apache Flink running
 
 
-### Distributing Flink Samples
-#### Assemble
+## Distributing Flink Samples
 Use gradle to assemble a distribution folder containing the Flink programs as a ready-to-deploy 
 uber-jar called `pravega-flink-examples-<VERSION>-all.jar`:
 
@@ -23,22 +22,7 @@ flink-connector-examples/build/install/pravega-flink-examples/bin:
 run-example
 
 flink-connector-examples/build/install/pravega-flink-examples/lib:
-pravega-flink-examples-<VERSION>-all.jar
-```
-
-#### Upload
-The `upload` task makes it easy to upload the sample binaries to your cluster. First, configure 
-Gradle with the address of a node in your cluster.   Edit `~/.gradle/gradle.properties` to 
-specify a value for `dcosAddress`.
-
-```
-$ cat ~/.gradle/gradle.properties
-dcosAddress=10.240.124.164
-```
-
-Then, upload the samples to the cluster. They will be copied to `/home/centos` on the target node.
-```
-$ ./gradlew upload
+pravega-flink-examples-VERSION-all.jar
 ```
 
 ---

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,6 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-### clusters
-dcosAddress=master.mesos
-
 ### dependencies
 pravegaVersion=0.3.0-50.68f85f0-SNAPSHOT
 flinkConnectorVersion=0.3.0-101.4d4269d-SNAPSHOT

--- a/pravega-client-examples/README.md
+++ b/pravega-client-examples/README.md
@@ -6,6 +6,11 @@ Set of example applications to demonstrate the features and APIs of Pravega as w
 1. Pravega running (see [here](http://pravega.io/docs/latest/getting-started/) for instructions)
 2. Build `pravega-samples` repository
 
+Please note that after building `pravega-samples`, all the executables used here are located in:
+```
+pravega-samples/pravega-client-examples/build/install/pravega-client-examples
+```
+
 ---
 
 # Examples Catalog


### PR DESCRIPTION
**Change log description**
This PR deletes the `upload` instructions from `flink-connector-examples` README, as well as the associated tasks/properties in the main `build.gradle` file and `gradle.properties` file, respectively. 

**Purpose of the change**
Fixes #116.

**What the code does**
Delete unnecessary README steps and build tasks to simplify the instructions for end-users.

**How to verify it**
Clone the PR changes and execute `gradlew installDist`. All the sample applications should be working as before this change.