### PR TITLE
Issue 123: Removed scaleGracePeriod from Hadoop wordcount sample

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ flinkVersion=1.4.0
 hadoopVersion=2.8.1
 scalaVersion=2.11.8
 sparkVersion=2.2.0
-hadoopConnectorVersion=0.3.0-17.a171316-SNAPSHOT
+hadoopConnectorVersion=0.3.0-20.1a0dde3-SNAPSHOT

--- a/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/wordcount/PravegaOutputFormat.java
+++ b/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/wordcount/PravegaOutputFormat.java
@@ -52,7 +52,6 @@ public class PravegaOutputFormat<V> extends OutputFormat<String, V> {
 
     private static final long DEFAULT_TXN_TIMEOUT_MS = 30000L;
     private static final long DEFAULT_TXN_MAX_EXECUTION_TIME_MS = 30000L;
-    private static final long DEFAULT_TXN_SCALE_GRACE_PERIOD_MS = 30000L;
     private static final long DEFAULT_PING_LEASE_MS = 30000L;
 
     // client factory
@@ -100,7 +99,6 @@ public class PravegaOutputFormat<V> extends OutputFormat<String, V> {
 
         EventStreamWriter<V> writer = clientFactory.createEventWriter(streamName, deserializer, EventWriterConfig.builder()
                 .transactionTimeoutTime(DEFAULT_TXN_TIMEOUT_MS)
-                .transactionTimeoutScaleGracePeriod(DEFAULT_TXN_SCALE_GRACE_PERIOD_MS)
                 .build());
 
         return new PravegaOutputRecordWriter<V>(writer);


### PR DESCRIPTION
**Change log description**
Removed `DEFAULT_TXN_SCALE_GRACE_PERIOD_MS` constant and `transactionTimeoutScaleGracePeriod` call from `PravegaOutputFormat.java`. Moreover, this PR also updates the `hadoopConnectorVersion` version in `gradle.properties` to the last available artifact in version `0.3.0` so this fix can be tested.

**Purpose of the change**
Fixes #123.

**What the code does**
Removes operations involving `scaleGracePeriod` in Hadoop wordcount sample that prevented gradle build to succeed.

**How to verify it**
Clone this PR and execute `./gradlew installDist`, it should be working. Also, execute the Hadoop wordcount example; it should be working as it was before this fix. 