### PR TITLE
Issue 130: Updated artifacts version to 0.4.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,8 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### dependencies
-pravegaVersion=0.3.0
-flinkConnectorVersion=0.3.0
+pravegaVersion=0.4.0-50.63aea88-SNAPSHOT
+flinkConnectorVersion=0.4.0-103.7971206-SNAPSHOT
 
 ### Pravega-samples output library
 samplesVersion=0.3.0
@@ -21,4 +21,4 @@ flinkVersion=1.4.0
 hadoopVersion=2.8.1
 scalaVersion=2.11.8
 sparkVersion=2.2.0
-hadoopConnectorVersion=0.3.0
+hadoopConnectorVersion=0.4.0-21.28e4b47-SNAPSHOT


### PR DESCRIPTION
**Change log description**
Changed the `develop` branch `gradle.properties` artifacts of Pravega and Hadoop/Flink connectors to version `0.4.0`.

**Purpose of the change**
Fixes #130.

**What the code does**
Upgrade the version of project dependency artifacts.

**How to verify it**
Clone the `develop` branch and execute `./gradlew installDist`, the build should be downloading the new dependencies and passing.