### PR TITLE
Issue 143: Update samplesVersion to 0.3.2-SNAPSHOT.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pravegaVersion=0.3.1
 flinkConnectorVersion=0.3.1
 
 ### Pravega-samples output library
-samplesVersion=0.3.1
+samplesVersion=0.3.2-SNAPSHOT
 
 ### Flink-connector examples
 flinkVersion=1.4.0


### PR DESCRIPTION
**Change log description**
Updated `gradle.properties` of r0.3 to set `samplesVersion=0.3.2-SNAPSHOT`. 

**Purpose of the change**
Fixes #143.

**What the code does**
Upgrade `samplesVersion` in `gradle.properties`.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>