### PR TITLE
Issue 153: Upgrade artifacts version to 0.3.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,11 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### dependencies
-pravegaVersion=0.3.1
-flinkConnectorVersion=0.3.1
+pravegaVersion=0.3.2
+flinkConnectorVersion=0.3.2
 
 ### Pravega-samples output library
-samplesVersion=0.3.2-SNAPSHOT
+samplesVersion=0.3.2
 
 ### Flink-connector examples
 flinkVersion=1.4.0
@@ -21,4 +21,4 @@ flinkVersion=1.4.0
 hadoopVersion=2.8.1
 scalaVersion=2.11.8
 sparkVersion=2.2.0
-hadoopConnectorVersion=0.3.1
+hadoopConnectorVersion=0.3.2


### PR DESCRIPTION
**Change log description**
Upgraded artifacts to version `0.3.2`.

**Purpose of the change**
Fixes #153.

**What the code does**
Updates artifact versions in `gradle.properties` to `0.3.2`.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>