### PR TITLE
Issue 160: Use new StreamCuts API call to get the end of a Stream slice

### DIFF
--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
@@ -37,7 +37,7 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.util.Collector;
@@ -98,7 +98,7 @@ public class StreamBookmarker {
         DataStreamSink<SensorStreamSlice> dataStreamSink = env.addSource(reader)
                                                               .setParallelism(Constants.PARALLELISM)
                                                               .keyBy(0)
-                                                              .process(new Bookmarker(pravegaControllerURI))
+                                                              .process((KeyedProcessFunction) new Bookmarker(pravegaControllerURI))
                                                               .addSink(writer);
 
         // Execute within the Flink environment.
@@ -112,7 +112,7 @@ public class StreamBookmarker {
  * the state of the Flink reader. The main task of this class is to output SensorStreamSlice objects that represent events
  * created by DataProducer whose value is < 0.
  */
-class Bookmarker extends ProcessFunction<Tuple2<Integer, Double>, SensorStreamSlice> {
+class Bookmarker extends KeyedProcessFunction<Long, Tuple2<Integer, Double>, SensorStreamSlice> {
 
     private static final Logger LOG = LoggerFactory.getLogger(Bookmarker.class);
     private static final ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(Constants.PARALLELISM);

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
@@ -92,6 +92,7 @@ public class StreamBookmarker {
         // Initialize the Flink execution environment.
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment()
                                                                          .enableCheckpointing(CHECKPOINT_INTERVAL);
+        env.getCheckpointConfig().setCheckpointTimeout(CHECKPOINT_INTERVAL);
 
         // Bookmark those sections of the stream with values < 0 and write the output (StreamCuts).
         DataStreamSink<SensorStreamSlice> dataStreamSink = env.addSource(reader)

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
@@ -37,7 +37,7 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.util.Collector;
@@ -97,7 +97,7 @@ public class StreamBookmarker {
         DataStreamSink<SensorStreamSlice> dataStreamSink = env.addSource(reader)
                                                               .setParallelism(Constants.PARALLELISM)
                                                               .keyBy(0)
-                                                              .process((KeyedProcessFunction) new Bookmarker(pravegaControllerURI))
+                                                              .process(new Bookmarker(pravegaControllerURI))
                                                               .addSink(writer);
 
         // Execute within the Flink environment.
@@ -111,10 +111,10 @@ public class StreamBookmarker {
  * the state of the Flink reader. The main task of this class is to output SensorStreamSlice objects that represent events
  * created by DataProducer whose value is < 0.
  */
-class Bookmarker extends KeyedProcessFunction<Long, Tuple2<Integer, Double>, SensorStreamSlice> {
+class Bookmarker extends ProcessFunction<Tuple2<Integer, Double>, SensorStreamSlice> {
 
     private static final Logger LOG = LoggerFactory.getLogger(Bookmarker.class);
-    private static final ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(3);
+    private static final ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(Constants.PARALLELISM);
     private final URI pravegaControllerURI;
     private ReaderGroup readerGroup;
 
@@ -161,7 +161,7 @@ class Bookmarker extends KeyedProcessFunction<Long, Tuple2<Integer, Double>, Sen
                                                      .join()
                                                      .get(Stream.of(Constants.DEFAULT_SCOPE, Constants.PRODUCER_STREAM));
             LOG.warn("End bookmarking a stream slice at StreamCut: {} for sensor {}. The slice should contain all " +
-                    "events < 0 for a specific sensor sine wave.", endStreamCut, value.f0);
+                    "events < 0 for a sensor's sine wave.", endStreamCut, value.f0);
             sensorStreamSlice.setEnd(endStreamCut);
             out.collect(sensorStreamSlice);
             pendingBookmark.update(null);

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
@@ -54,7 +54,7 @@ public class StreamBookmarker {
     private static final Logger LOG = LoggerFactory.getLogger(StreamBookmarker.class);
 
     static final String READER_GROUP_NAME = "streamBookmarkerReaderGroup";
-    static final int CHECKPOINT_INTERVAL = 4000;
+    static final int PERIODIC_STREAMCUT_GENERATION_EVENTS = 50;
 
     public static void main(String[] args) throws Exception {
         // Initialize the parameter utility tool in order to retrieve input parameters.
@@ -91,7 +91,7 @@ public class StreamBookmarker {
 
         // Initialize the Flink execution environment.
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment()
-                                                                         .enableCheckpointing(CHECKPOINT_INTERVAL);
+                                                                         .enableCheckpointing(10000);
 
         // Bookmark those sections of the stream with values < 0 and write the output (StreamCuts).
         DataStreamSink<SensorStreamSlice> dataStreamSink = env.addSource(reader)
@@ -118,7 +118,9 @@ class Bookmarker extends KeyedProcessFunction<Long, Tuple2<Integer, Double>, Sen
     private final URI pravegaControllerURI;
     private ReaderGroup readerGroup;
 
-    private transient ValueState<SensorStreamSlice> pendingBookmark;
+    private transient ValueState<SensorStreamSlice> sensorStreamSlice;
+    private transient ValueState<StreamCut> periodicStreamCut;
+    private transient ValueState<Long> eventCounter;
 
     public Bookmarker(URI pravegaControllerURI) {
         this.pravegaControllerURI = pravegaControllerURI;
@@ -126,8 +128,12 @@ class Bookmarker extends KeyedProcessFunction<Long, Tuple2<Integer, Double>, Sen
 
     @Override
     public void open(Configuration parameters) {
-        pendingBookmark = getRuntimeContext().getState(new ValueStateDescriptor<>("pendingBookmarks",
+        sensorStreamSlice = getRuntimeContext().getState(new ValueStateDescriptor<>("sensorStreamSlice",
                 TypeInformation.of(new TypeHint<SensorStreamSlice>() {})));
+        periodicStreamCut = getRuntimeContext().getState(new ValueStateDescriptor<>("periodicStreamCut",
+                TypeInformation.of(new TypeHint<StreamCut>() {})));
+        eventCounter = getRuntimeContext().getState(new ValueStateDescriptor<>("eventCounter",
+                TypeInformation.of(new TypeHint<Long>() {})));
     }
 
     /**
@@ -145,17 +151,21 @@ class Bookmarker extends KeyedProcessFunction<Long, Tuple2<Integer, Double>, Sen
      */
     @Override
     public void processElement(Tuple2<Integer, Double> value, Context ctx, Collector<SensorStreamSlice> out) throws IOException {
-        if (value.f1 < 0 && pendingBookmark.value() == null) {
+        // Initialize the periodic StreamCut in case it is null.
+        if (periodicStreamCut.value() == null || eventCounter.value() == null) {
+            periodicStreamCut.update(StreamCut.UNBOUNDED);
+            eventCounter.update(0L);
+        }
+
+        if (value.f1 < 0 && sensorStreamSlice.value() == null) {
             // Instantiate a SensorStreamSlice object for this sensor.
             SensorStreamSlice sensorStreamSlice = new SensorStreamSlice(value.f0);
-            // Set the current ReaderGroup StreamCut as the beginning of the slice of events of interest.
-            StreamCut startStreamCut = getReaderGroup().getStreamCuts()
-                                                       .get(Stream.of(Constants.DEFAULT_SCOPE, Constants.PRODUCER_STREAM));
-            sensorStreamSlice.setStart(startStreamCut);
-            pendingBookmark.update(sensorStreamSlice);
-            LOG.warn("Start bookmarking a stream slice at StreamCut: {} for sensor {}.", startStreamCut, value.f0);
-        } else if (value.f1 >= 0 && pendingBookmark.value() != null) {
-            SensorStreamSlice sensorStreamSlice = pendingBookmark.value();
+            // Set the latest periodically generated StreamCut as the beginning of the slice of events of interest.
+            sensorStreamSlice.setStart(periodicStreamCut.value());
+            this.sensorStreamSlice.update(sensorStreamSlice);
+            LOG.warn("Start bookmarking a stream slice at StreamCut: {} for sensor {}.", periodicStreamCut.value(), value.f0);
+        } else if (value.f1 >= 0 && sensorStreamSlice.value() != null) {
+            SensorStreamSlice sensorStreamSlice = this.sensorStreamSlice.value();
             // We found the first event > 0, so we want a StreamCut from this point onward to complete the slice.
             StreamCut endStreamCut = getReaderGroup().generateStreamCuts(executor)
                                                      .join()
@@ -164,8 +174,17 @@ class Bookmarker extends KeyedProcessFunction<Long, Tuple2<Integer, Double>, Sen
                     "events < 0 for a specific sensor sine wave.", endStreamCut, value.f0);
             sensorStreamSlice.setEnd(endStreamCut);
             out.collect(sensorStreamSlice);
-            pendingBookmark.update(null);
+            this.sensorStreamSlice.update(null);
         }
+
+        // Generate a StreamCut every PERIODIC_STREAMCUT_GENERATION_EVENTS events.
+        if (eventCounter.value() % StreamBookmarker.PERIODIC_STREAMCUT_GENERATION_EVENTS == 0) {
+            periodicStreamCut.update(getReaderGroup().generateStreamCuts(executor)
+                                                     .join()
+                                                     .get(Stream.of(Constants.DEFAULT_SCOPE, Constants.PRODUCER_STREAM)));
+        }
+
+        eventCounter.update(eventCounter.value() + 1);
     }
 
     /**

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
@@ -12,7 +12,6 @@ package io.pravega.example.flink.streamcuts.process;
 
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
-import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
@@ -27,7 +26,8 @@ import io.pravega.example.flink.streamcuts.SensorStreamSlice;
 import io.pravega.example.flink.streamcuts.serialization.Tuple2DeserializationSchema;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeHint;
@@ -111,16 +111,18 @@ public class StreamBookmarker {
  * the state of the Flink reader. The main task of this class is to output SensorStreamSlice objects that represent events
  * created by DataProducer whose value is < 0.
  */
-class Bookmarker extends ProcessFunction<Tuple2<Integer, Double>, SensorStreamSlice>{
+class Bookmarker extends ProcessFunction<Tuple2<Integer, Double>, SensorStreamSlice> {
 
     private static final Logger LOG = LoggerFactory.getLogger(Bookmarker.class);
     private final URI pravegaControllerURI;
     private ReaderGroup readerGroup;
+    private transient ScheduledExecutorService executor;
 
     private transient ValueState<SensorStreamSlice> pendingBookmark;
 
     public Bookmarker(URI pravegaControllerURI) {
         this.pravegaControllerURI = pravegaControllerURI;
+        this.executor = new ScheduledThreadPoolExecutor(1);
     }
 
     @Override
@@ -147,32 +149,23 @@ class Bookmarker extends ProcessFunction<Tuple2<Integer, Double>, SensorStreamSl
         if (value.f1 < 0 && pendingBookmark.value() == null) {
             // Instantiate a SensorStreamSlice object for this sensor.
             SensorStreamSlice sensorStreamSlice = new SensorStreamSlice(value.f0);
-
             // Set the current ReaderGroup StreamCut as the beginning of the slice of events of interest.
-            StreamCut startStreamCut = getReaderGroup().getStreamCuts().get(Stream.of(Constants.DEFAULT_SCOPE, Constants.PRODUCER_STREAM));
+            StreamCut startStreamCut = getReaderGroup().getStreamCuts()
+                                                       .get(Stream.of(Constants.DEFAULT_SCOPE, Constants.PRODUCER_STREAM));
             sensorStreamSlice.setStart(startStreamCut);
             pendingBookmark.update(sensorStreamSlice);
             LOG.warn("Start bookmarking a stream slice at: {} for sensor {}.", startStreamCut, value.f0);
         } else if (value.f1 >= 0 && pendingBookmark.value() != null) {
             SensorStreamSlice sensorStreamSlice = pendingBookmark.value();
-            StreamCut currentStreamCut = getReaderGroup().getStreamCuts().get(Stream.of(Constants.DEFAULT_SCOPE, Constants.PRODUCER_STREAM));
-
-            // If this is the first event > 0, then we need to keep the current StreamCut. Note that this is needed to
-            // check for the next StreamCut strictly beyond the current reader position, as the current StreamCut is
-            // likely to represent past reader positions that may not contain all events < 0 for this sensor.
-            if (sensorStreamSlice.getEnd() == null) {
-                LOG.warn("Initialize sensorStreamSlice end value to look for the next updated StreamCut: {} for sensor {}.", currentStreamCut, value.f0);
-                sensorStreamSlice.setEnd(currentStreamCut);
-            } else if (checkUpdatedStreamCutPositions(sensorStreamSlice.getEnd(), currentStreamCut)) {
-                // Only when all the positions in the previous StreamCut are updated in currentStreamCut, we can ensure
-                // that the slice contains at least all the evens of interest.
-                sensorStreamSlice.setEnd(currentStreamCut);
-                out.collect(sensorStreamSlice);
-                LOG.warn("Found next end StreamCut for sensor {}: {}. The slice should contain all events < 0 for a specific sensor sine wave.", value.f0, currentStreamCut);
-                sensorStreamSlice = null;
-            }
-
-            pendingBookmark.update(sensorStreamSlice);
+            // We found the first event > 0, so we want a StreamCut from this point onward to complete the slice.
+            StreamCut currentStreamCut = getReaderGroup().generateStreamCuts(executor)
+                                                         .join()
+                                                         .get(Stream.of(Constants.DEFAULT_SCOPE, Constants.PRODUCER_STREAM));
+            sensorStreamSlice.setEnd(currentStreamCut);
+            out.collect(sensorStreamSlice);
+            LOG.warn("Found next end StreamCut for sensor {}: {}. The slice should contain all events < 0 for a specific sensor sine wave.",
+                    value.f0, currentStreamCut);
+            pendingBookmark.update(null);
         }
     }
 
@@ -190,27 +183,6 @@ class Bookmarker extends ProcessFunction<Tuple2<Integer, Double>, SensorStreamSl
         }
 
         return readerGroup;
-    }
-
-    /**
-     * This method compares the positions of two StreamCuts. Concretely, this method verifies that all the positions
-     * from the first input StreamCut are higher compared to the second input argument. This ensures that all the
-     * reading positions of interest for the first StreamCut have been updated in the second one.
-     *
-     * @param streamCut StreamCut at a given point in time.
-     * @param toCompare StreamCut to check if all its reading positions are higher compared to the first input argument.
-     * @return Whether all the common positions between two StreamCuts are higher for the second one.
-     */
-    private boolean checkUpdatedStreamCutPositions(StreamCut streamCut, StreamCut toCompare) {
-        Map<Segment, Long> streamCutPositions = streamCut.asImpl().getPositions();
-        Map<Segment, Long> toComparePositions = toCompare.asImpl().getPositions();
-        for (Segment s: streamCutPositions.keySet()) {
-            if (toComparePositions.containsKey(s) && toComparePositions.get(s) <= streamCutPositions.get(s)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,8 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### dependencies
-pravegaVersion=0.4.0-50.9a734d2-SNAPSHOT
-flinkConnectorVersion=0.4.0-100.d588197-SNAPSHOT
+pravegaVersion=0.4.0-50.2f44817-SNAPSHOT
+flinkConnectorVersion=0.4.0-135.37c35f7-SNAPSHOT
 
 ### Pravega-samples output library
 samplesVersion=0.4.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,8 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### dependencies
-pravegaVersion=0.4.0-50.2f44817-SNAPSHOT
-flinkConnectorVersion=0.4.0-135.37c35f7-SNAPSHOT
+pravegaVersion=0.4.0-50.da91e55-SNAPSHOT
+flinkConnectorVersion=0.4.0-96.54ccab2-SNAPSHOT
 
 ### Pravega-samples output library
 samplesVersion=0.4.0-SNAPSHOT


### PR DESCRIPTION
**Change log description**
Modify Flink StreamCuts sample to use the new `generateStreamCuts` call.

**Purpose of the change**
Fixes #160.

**What the code does**
Replaces old code to get a new `StreamCut` after a given position by the new API call `generateStreamCuts`. This PR required the update of FlinkConnector with a Pravega version containing PR https://github.com/pravega/pravega/pull/2980.

**How to verify it**
The app should be working as before.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>