### PR TITLE
Issue 168: Updated artifacts to 0.4.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,11 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### dependencies
-pravegaVersion=0.4.0-50.da91e55-SNAPSHOT
-flinkConnectorVersion=0.4.0-96.54ccab2-SNAPSHOT
+pravegaVersion=0.4.0
+flinkConnectorVersion=0.4.0
 
 ### Pravega-samples output library
-samplesVersion=0.4.0-SNAPSHOT
+samplesVersion=0.4.0
 
 ### Flink-connector examples
 flinkVersion=1.6.0
@@ -21,4 +21,4 @@ flinkVersion=1.6.0
 hadoopVersion=2.8.1
 scalaVersion=2.11.8
 sparkVersion=2.2.0
-hadoopConnectorVersion=0.4.0-21.28e4b47-SNAPSHOT
+hadoopConnectorVersion=0.4.0


### PR DESCRIPTION
**Change log description**
* Updated Pravega, Flink and Hadoop connector version to 0.4.0.
* Updated samples version to 0.4.0.

**Purpose of the change**
Fixes #168.

**What the code does**
Updates artifact versions in `gradle.properties` to `0.4.0`.