### PR TITLE
Issue 170: Updated samplesVersion to 0.5.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pravegaVersion=0.4.0
 flinkConnectorVersion=0.4.0
 
 ### Pravega-samples output library
-samplesVersion=0.4.0
+samplesVersion=0.5.0-SNAPSHOT
 
 ### Flink-connector examples
 flinkVersion=1.6.0


### PR DESCRIPTION
**Change log description**
Updated samplesVersion to 0.5.0-SNAPSHOT.

**Purpose of the change**
Fixes #170.

**What the code does**
Sets `samplesVersion` to 0.5.0-SNAPSHOT in `gradle.properties`.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>