### PR TITLE
Issue 184: Add Lombok dependency

### DIFF
--- a/flink-connector-examples/build.gradle
+++ b/flink-connector-examples/build.gradle
@@ -26,6 +26,7 @@ ext {
 }
 
 dependencies {
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
     compile "org.scala-lang.modules:scala-java8-compat_2.11:${scalaJava8CompatVersion}"
     compile "io.pravega:pravega-connectors-flink_2.11:${flinkConnectorVersion}"
     compile "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@
 ### dependencies
 pravegaVersion=0.4.0
 flinkConnectorVersion=0.4.0
+lombokVersion=1.18.6
 
 ### Pravega-samples output library
 samplesVersion=0.4.0

--- a/hadoop-connector-examples/build.gradle
+++ b/hadoop-connector-examples/build.gradle
@@ -35,6 +35,7 @@ repositories {
 }
 
 dependencies {
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
     compile     "io.pravega:pravega-connectors-hadoop:${hadoopConnectorVersion}"
     compileOnly "org.apache.hadoop:hadoop-common:${hadoopVersion}"
     compileOnly "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"

--- a/pravega-client-examples/build.gradle
+++ b/pravega-client-examples/build.gradle
@@ -25,6 +25,8 @@ ext {
 }
 
 dependencies {
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    
     testCompile "junit:junit:${junitVersion}"
 
     compile "io.pravega:pravega-client:${pravegaVersion}",

--- a/scenarios/pravega-flink-connector-sql-samples/build.gradle
+++ b/scenarios/pravega-flink-connector-sql-samples/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:2.8.9"
 
     compile "joda-time:joda-time:2.7"
-    compile "org.projectlombok:lombok:1.16.18"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
 }
 
 task scriptConnectorTableApiSamples(type: CreateStartScripts) {

--- a/scenarios/turbine-heat-processor/build.gradle
+++ b/scenarios/turbine-heat-processor/build.gradle
@@ -26,6 +26,7 @@ ext {
 }
 
 dependencies {
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
     compile "org.scala-lang.modules:scala-java8-compat_2.11:${scalaJava8CompatVersion}"
     compile "io.pravega:pravega-connectors-flink_2.11:${flinkConnectorVersion}"
     compile "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"

--- a/scenarios/turbine-heat-sensor/build.gradle
+++ b/scenarios/turbine-heat-sensor/build.gradle
@@ -25,6 +25,8 @@ ext {
 }
 
 dependencies {
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+
     testCompile "junit:junit:${junitVersion}"
 
     compile "io.pravega:pravega-client:${pravegaVersion}",


### PR DESCRIPTION

Building with gradlew installDist fails with the following error:

```
pravega-samples/hadoop-connector-examples/src/main/java/io/pravega/example/spark/wordcount/WordCount.java:30: warning: lombok.javac.apt.LombokProcessor could not be initialized. Lombok will not run during this compilation: java.lang.IllegalArgumentException: com.sun.tools.javac.api.ClientCodeWrapper$WrappedStandardJavaFileManager extends com.sun.tools.javac.api.ClientCodeWrapper$WrappedJavaFileManager implements javax.tools.StandardJavaFileManager
```

This occurs because the Lombok dependency is not included in the samples. It should be included as shown in https://projectlombok.org/setup/gradle. This PR simply adds `compileOnly "org.projectlombok:lombok:${lombokVersion}"` to each project.

Signed-off-by: Claudio Fahey <claudio.fahey@dell.com>