### PR TITLE
[issue-197] Update samples to use r0.5 artifacts

### DIFF
--- a/flink-connector-examples/build.gradle
+++ b/flink-connector-examples/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile "io.pravega:pravega-connectors-flink_$flinkScalaVersion:${flinkConnectorVersion}"
     compile "org.apache.flink:flink-streaming-java_$flinkScalaVersion:${flinkVersion}"
     compile "org.apache.flink:flink-streaming-scala_$flinkScalaVersion:${flinkVersion}"
-    compile "org.slf4j:slf4j-log4j12:1.7.25"
+    compile "org.slf4j:slf4j-log4j12:${slf4jLog4JVersion}"
 }
 
 shadowJar {

--- a/flink-connector-examples/build.gradle
+++ b/flink-connector-examples/build.gradle
@@ -21,22 +21,19 @@ apply plugin: 'eclipse'
 sourceCompatibility = "1.8"
 archivesBaseName = 'pravega-flink-examples'
 
-ext {
-    scalaJava8CompatVersion = '0.7.0'
-}
-
 dependencies {
-    compile "org.scala-lang.modules:scala-java8-compat_2.11:${scalaJava8CompatVersion}"
-    compile "io.pravega:pravega-connectors-flink_2.11:${flinkConnectorVersion}"
-    compile "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"
-    compile "org.apache.flink:flink-streaming-scala_2.11:${flinkVersion}"
+    compile "de.javakaffee:kryo-serializers:$kryoSerializerVersion"
+    compile "org.scala-lang.modules:scala-java8-compat_$flinkScalaVersion:${scalaJava8CompatVersion}"
+    compile "io.pravega:pravega-connectors-flink_$flinkScalaVersion:${flinkConnectorVersion}"
+    compile "org.apache.flink:flink-streaming-java_$flinkScalaVersion:${flinkVersion}"
+    compile "org.apache.flink:flink-streaming-scala_$flinkScalaVersion:${flinkVersion}"
     compile "org.slf4j:slf4j-log4j12:1.7.25"
 }
 
 shadowJar {
     dependencies {
-        include dependency("org.scala-lang.modules:scala-java8-compat_2.11")
-        include dependency("io.pravega:pravega-connectors-flink_2.11")
+        include dependency("org.scala-lang.modules:scala-java8-compat_$flinkScalaVersion")
+        include dependency("io.pravega:pravega-connectors-flink_$flinkScalaVersion")
     }
 }
 

--- a/flink-connector-examples/build.gradle
+++ b/flink-connector-examples/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = "1.8"
 archivesBaseName = 'pravega-flink-examples'
 
 dependencies {
-    compile "de.javakaffee:kryo-serializers:$kryoSerializerVersion"
+    compile "de.javakaffee:kryo-serializers:${kryoSerializerVersion}"
     compile "org.scala-lang.modules:scala-java8-compat_$flinkScalaVersion:${scalaJava8CompatVersion}"
     compile "io.pravega:pravega-connectors-flink_$flinkScalaVersion:${flinkConnectorVersion}"
     compile "org.apache.flink:flink-streaming-java_$flinkScalaVersion:${flinkVersion}"

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
@@ -23,6 +23,7 @@ import io.pravega.connectors.flink.serialization.PravegaSerialization;
 import io.pravega.example.flink.Utils;
 import io.pravega.example.flink.streamcuts.Constants;
 import io.pravega.example.flink.streamcuts.SensorStreamSlice;
+import io.pravega.example.flink.streamcuts.serialization.GuavaImmutableMapSerializer;
 import io.pravega.example.flink.streamcuts.serialization.Tuple2DeserializationSchema;
 import java.io.IOException;
 import java.net.URI;
@@ -93,6 +94,7 @@ public class StreamBookmarker {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment()
                                                                          .enableCheckpointing(CHECKPOINT_INTERVAL);
         env.getCheckpointConfig().setCheckpointTimeout(CHECKPOINT_INTERVAL);
+        GuavaImmutableMapSerializer.registerSerializers(env.getConfig());
 
         // Bookmark those sections of the stream with values < 0 and write the output (StreamCuts).
         DataStreamSink<SensorStreamSlice> dataStreamSink = env.addSource(reader)

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/serialization/GuavaImmutableMapSerializer.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/serialization/GuavaImmutableMapSerializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package io.pravega.example.flink.streamcuts.serialization;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.pravega.shaded.com.google.common.collect.ImmutableMap;
+import io.pravega.shaded.com.google.common.collect.ImmutableTable;
+import io.pravega.shaded.com.google.common.collect.Maps;
+import org.apache.flink.api.common.ExecutionConfig;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Serializer for handling Guava ImmutableMap used in StreamCutImpl
+ */
+
+public class GuavaImmutableMapSerializer extends Serializer<ImmutableMap<Object, ? extends Object>> {
+
+    private static final boolean DOES_NOT_ACCEPT_NULL = true;
+    private static final boolean IMMUTABLE = true;
+
+    public GuavaImmutableMapSerializer() {
+        super(DOES_NOT_ACCEPT_NULL, IMMUTABLE);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, ImmutableMap<Object, ? extends Object> immutableMap) {
+        kryo.writeObject(output, Maps.newHashMap(immutableMap));
+    }
+
+    @Override
+    public ImmutableMap<Object, Object> read(Kryo kryo, Input input, Class<? extends ImmutableMap<Object, ? extends Object>> type) {
+        Map map = kryo.readObject(input, HashMap.class);
+        return ImmutableMap.copyOf(map);
+    }
+
+    private enum DummyEnum {
+        VALUE1,
+        VALUE2
+    }
+
+    public static void registerSerializers(ExecutionConfig conf) {
+
+        Class<GuavaImmutableMapSerializer> serializer = GuavaImmutableMapSerializer.class;
+
+        conf.registerTypeWithKryoSerializer(ImmutableMap.class, serializer);
+        conf.registerTypeWithKryoSerializer(ImmutableMap.of().getClass(), serializer);
+        Object o1 = new Object();
+        Object o2 = new Object();
+        conf.registerTypeWithKryoSerializer(ImmutableMap.of(o1, o1).getClass(), serializer);
+        conf.registerTypeWithKryoSerializer(ImmutableMap.of(o1, o1, o2, o2).getClass(), serializer);
+        Map<DummyEnum, Object> enumMap = new EnumMap<>(DummyEnum.class);
+        for (DummyEnum e : DummyEnum.values()) {
+            enumMap.put(e, o1);
+        }
+        conf.registerTypeWithKryoSerializer(ImmutableMap.copyOf(enumMap).getClass(), serializer);
+        ImmutableTable<Object, Object, Object> denseImmutableTable = ImmutableTable.builder().put("a", 1, 1).put("b", 1, 1).build();
+        conf.registerTypeWithKryoSerializer(denseImmutableTable.rowMap().getClass(), serializer);
+        conf.registerTypeWithKryoSerializer(((Map) denseImmutableTable.rowMap().get("a")).getClass(), serializer);
+        conf.registerTypeWithKryoSerializer(denseImmutableTable.columnMap().getClass(), serializer);
+        conf.registerTypeWithKryoSerializer(((Map) denseImmutableTable.columnMap().get(1)).getClass(), serializer);
+    }
+}

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/serialization/GuavaImmutableMapSerializer.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/serialization/GuavaImmutableMapSerializer.java
@@ -26,7 +26,6 @@ import java.util.Map;
 /**
  * Serializer for handling Guava ImmutableMap used in StreamCutImpl
  */
-
 public class GuavaImmutableMapSerializer extends Serializer<ImmutableMap<Object, ? extends Object>> {
 
     private static final boolean DOES_NOT_ACCEPT_NULL = true;

--- a/flink-connector-examples/src/main/resources/log4j.properties
+++ b/flink-connector-examples/src/main/resources/log4j.properties
@@ -16,3 +16,6 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 
 log4j.logger.io.pravega.end2end=INFO
+log4j.logger.io.pravega.client.stream.impl.ControllerImpl=OFF
+log4j.logger.org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer=OFF
+log4j.logger.org.apache.flink.metrics.MetricGroup=OFF

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,21 +7,23 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-### dependencies
+### Pravega dependencies
 pravegaVersion=0.5.0-2223.ce3ba81-SNAPSHOT
-flinkConnectorVersion=0.5.0-75.01ba05e-SNAPSHOT
 
 ### Pravega-samples output library
 samplesVersion=0.5.0-SNAPSHOT
 
-### Flink-connector examples
+### Flink-connector dependencies
+flinkConnectorVersion=0.5.0-75.01ba05e-SNAPSHOT
 flinkVersion=1.7.2
 flinkScalaVersion=2.12
 
-#hadoop connector
-hadoopVersion=2.8.1
-sparkVersion=2.2.0
+### hadoop connector dependencies
 hadoopConnectorVersion=0.5.0-29.d6fa817-SNAPSHOT
 
-scalaJava8CompatVersion=0.9.0
+### Samples application dependencies
+hadoopVersion=2.8.1
 kryoSerializerVersion=0.45
+sparkVersion=2.2.0
+scalaJava8CompatVersion=0.9.0
+slf4jLog4JVersion=1.7.25

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,17 +8,20 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### dependencies
-pravegaVersion=0.4.0
-flinkConnectorVersion=0.4.0
+pravegaVersion=0.5.0-2223.ce3ba81-SNAPSHOT
+flinkConnectorVersion=0.5.0-145.206fff3-SNAPSHOT
 
 ### Pravega-samples output library
 samplesVersion=0.5.0-SNAPSHOT
 
 ### Flink-connector examples
-flinkVersion=1.6.0
+flinkVersion=1.7.2
+flinkScalaVersion=2.12
 
 #hadoop connector
 hadoopVersion=2.8.1
-scalaVersion=2.11.8
 sparkVersion=2.2.0
-hadoopConnectorVersion=0.4.0
+hadoopConnectorVersion=0.5.0-28.e788a2a-SNAPSHOT
+
+scalaJava8CompatVersion=0.9.0
+kryoSerializerVersion=0.45

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 #
 ### dependencies
 pravegaVersion=0.5.0-2223.ce3ba81-SNAPSHOT
-flinkConnectorVersion=0.5.0-145.206fff3-SNAPSHOT
+flinkConnectorVersion=0.5.0-75.01ba05e-SNAPSHOT
 
 ### Pravega-samples output library
 samplesVersion=0.5.0-SNAPSHOT
@@ -21,7 +21,7 @@ flinkScalaVersion=2.12
 #hadoop connector
 hadoopVersion=2.8.1
 sparkVersion=2.2.0
-hadoopConnectorVersion=0.5.0-28.e788a2a-SNAPSHOT
+hadoopConnectorVersion=0.5.0-29.d6fa817-SNAPSHOT
 
 scalaJava8CompatVersion=0.9.0
 kryoSerializerVersion=0.45

--- a/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/PravegaFixedSegmentsOutputFormat.java
+++ b/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/PravegaFixedSegmentsOutputFormat.java
@@ -60,15 +60,15 @@ public class PravegaFixedSegmentsOutputFormat<V> extends OutputFormat<String, V>
     private static final Logger log = LoggerFactory.getLogger(PravegaFixedSegmentsOutputFormat.class);
 
     // Pravega scope name
-    public static final String SCOPE_NAME = "pravega.scope";
+    public static final String OUTPUT_SCOPE_NAME = "output.pravega.scope";
     // Pravega stream name
-    public static final String STREAM_NAME = "pravega.stream";
+    public static final String OUTPUT_STREAM_NAME = "output.pravega.stream";
     // Pravega stream segments
-    public static final String STREAM_SEGMENTS = "pravega.stream.segments";
+    public static final String OUTPUT_STREAM_SEGMENTS = "output.pravega.stream.segments";
     // Pravega uri string
-    public static final String URI_STRING = "pravega.uri";
+    public static final String OUTPUT_URI_STRING = "output.pravega.uri";
     // Pravega deserializer class name
-    public static final String DESERIALIZER = "pravega.deserializer";
+    public static final String OUTPUT_DESERIALIZER = "output.pravega.deserializer";
 
     static final long DEFAULT_TXN_TIMEOUT_MS = 30000L;
 
@@ -87,15 +87,15 @@ public class PravegaFixedSegmentsOutputFormat<V> extends OutputFormat<String, V>
     public RecordWriter<String, V> getRecordWriter(TaskAttemptContext context) throws IOException, InterruptedException {
 
         Configuration conf = context.getConfiguration();
-        final String scopeName = Optional.ofNullable(conf.get(SCOPE_NAME)).orElseThrow(() ->
-                new IOException("The input scope name must be configured (" + SCOPE_NAME + ")"));
-        final String streamName = Optional.ofNullable(conf.get(STREAM_NAME)).orElseThrow(() ->
-                new IOException("The input stream name must be configured (" + STREAM_NAME + ")"));
-        final URI controllerURI = Optional.ofNullable(conf.get(URI_STRING)).map(URI::create).orElseThrow(() ->
-                new IOException("The Pravega controller URI must be configured (" + URI_STRING + ")"));
-        final String deserializerClassName = Optional.ofNullable(conf.get(DESERIALIZER)).orElseThrow(() ->
-                new IOException("The event deserializer must be configured (" + DESERIALIZER + ")"));
-        final int segments = Integer.parseInt(conf.get(STREAM_SEGMENTS, "3"));
+        final String scopeName = Optional.ofNullable(conf.get(OUTPUT_SCOPE_NAME)).orElseThrow(() ->
+                new IOException("The input scope name must be configured (" + OUTPUT_SCOPE_NAME + ")"));
+        final String streamName = Optional.ofNullable(conf.get(OUTPUT_STREAM_NAME)).orElseThrow(() ->
+                new IOException("The input stream name must be configured (" + OUTPUT_STREAM_NAME + ")"));
+        final URI controllerURI = Optional.ofNullable(conf.get(OUTPUT_URI_STRING)).map(URI::create).orElseThrow(() ->
+                new IOException("The Pravega controller URI must be configured (" + OUTPUT_URI_STRING + ")"));
+        final String deserializerClassName = Optional.ofNullable(conf.get(OUTPUT_DESERIALIZER)).orElseThrow(() ->
+                new IOException("The event deserializer must be configured (" + OUTPUT_DESERIALIZER + ")"));
+        final int segments = Integer.parseInt(conf.get(OUTPUT_STREAM_SEGMENTS, "3"));
 
         StreamManager streamManager = StreamManager.create(controllerURI);
         streamManager.createScope(scopeName);

--- a/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/PravegaTeraSortOutputFormat.java
+++ b/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/PravegaTeraSortOutputFormat.java
@@ -48,14 +48,14 @@ public class PravegaTeraSortOutputFormat<V> extends PravegaFixedSegmentsOutputFo
     public RecordWriter<String, V> getRecordWriter(TaskAttemptContext context) throws IOException {
 
         Configuration conf = context.getConfiguration();
-        final String scopeName = Optional.ofNullable(conf.get(SCOPE_NAME)).orElseThrow(() ->
-                new IOException("The output scope name must be configured (" + SCOPE_NAME + ")"));
+        final String scopeName = Optional.ofNullable(conf.get(OUTPUT_SCOPE_NAME)).orElseThrow(() ->
+                new IOException("The output scope name must be configured (" + OUTPUT_SCOPE_NAME + ")"));
         final String outputStreamPrefix = Optional.ofNullable(conf.get(OUTPUT_STREAM_PREFIX)).orElseThrow(() ->
                 new IOException("The output stream prefix must be configured (" + OUTPUT_STREAM_PREFIX + ")"));
-        final URI controllerURI = Optional.ofNullable(conf.get(URI_STRING)).map(URI::create).orElseThrow(() ->
-                new IOException("The Pravega controller URI must be configured (" + URI_STRING + ")"));
-        final String deserializerClassName = Optional.ofNullable(conf.get(DESERIALIZER)).orElseThrow(() ->
-                new IOException("The event deserializer must be configured (" + DESERIALIZER + ")"));
+        final URI controllerURI = Optional.ofNullable(conf.get(OUTPUT_URI_STRING)).map(URI::create).orElseThrow(() ->
+                new IOException("The Pravega controller URI must be configured (" + OUTPUT_URI_STRING + ")"));
+        final String deserializerClassName = Optional.ofNullable(conf.get(OUTPUT_DESERIALIZER)).orElseThrow(() ->
+                new IOException("The event deserializer must be configured (" + OUTPUT_DESERIALIZER + ")"));
 
         final String outputStreamName = outputStreamPrefix + context.getTaskAttemptID().getTaskID().getId();
 

--- a/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/terasort/TeraGen.java
+++ b/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/terasort/TeraGen.java
@@ -61,6 +61,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.Checksum;
 
+import static io.pravega.example.hadoop.PravegaFixedSegmentsOutputFormat.OUTPUT_DESERIALIZER;
+import static io.pravega.example.hadoop.PravegaFixedSegmentsOutputFormat.OUTPUT_SCOPE_NAME;
+import static io.pravega.example.hadoop.PravegaFixedSegmentsOutputFormat.OUTPUT_STREAM_NAME;
+import static io.pravega.example.hadoop.PravegaFixedSegmentsOutputFormat.OUTPUT_STREAM_SEGMENTS;
+import static io.pravega.example.hadoop.PravegaFixedSegmentsOutputFormat.OUTPUT_URI_STRING;
+
 /**
  * This class is copied from apache/hadoop and modified by adding logic to
  * support PravegaInputFormat
@@ -305,11 +311,11 @@ public class TeraGen extends Configured implements Tool {
       return 2;
     }
     Path outputDir = new Path(args[1]);
-    getConf().setStrings("pravega.uri", args[2]);
-    getConf().setStrings("pravega.scope", args[3]);
-    getConf().setStrings("pravega.stream", args[4]);
-    getConf().setStrings("pravega.stream.segments", args[5]);
-    getConf().setStrings("pravega.deserializer", TextSerializer.class.getName());
+    getConf().setStrings(OUTPUT_URI_STRING, args[2]);
+    getConf().setStrings(OUTPUT_SCOPE_NAME, args[3]);
+    getConf().setStrings(OUTPUT_STREAM_NAME, args[4]);
+    getConf().setStrings(OUTPUT_STREAM_SEGMENTS, args[5]);
+    getConf().setStrings(OUTPUT_DESERIALIZER, TextSerializer.class.getName());
 
     Job job = Job.getInstance(getConf());
     setNumberOfRows(job, parseHumanLong(args[0]));

--- a/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/terasort/TeraSort.java
+++ b/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/terasort/TeraSort.java
@@ -55,6 +55,15 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
 
+import static io.pravega.connectors.hadoop.PravegaConfig.INPUT_DESERIALIZER;
+import static io.pravega.connectors.hadoop.PravegaConfig.INPUT_SCOPE_NAME;
+import static io.pravega.connectors.hadoop.PravegaConfig.INPUT_STREAM_NAME;
+import static io.pravega.connectors.hadoop.PravegaConfig.INPUT_URI_STRING;
+import static io.pravega.example.hadoop.PravegaFixedSegmentsOutputFormat.OUTPUT_DESERIALIZER;
+import static io.pravega.example.hadoop.PravegaFixedSegmentsOutputFormat.OUTPUT_SCOPE_NAME;
+import static io.pravega.example.hadoop.PravegaFixedSegmentsOutputFormat.OUTPUT_URI_STRING;
+import static io.pravega.example.hadoop.PravegaTeraSortOutputFormat.OUTPUT_STREAM_PREFIX;
+
 /**
  * This class is copied from apache/hadoop and modified by adding logic to
  * support PravegaInputFormat and PravegaOutputFormat
@@ -324,11 +333,16 @@ public class TeraSort extends Configured implements Tool {
     LOG.info("starting");
     Path inputDir = new Path(args[0]);
     Path outputDir = new Path(args[1]);
-    getConf().setStrings("input.pravega.uri", args[2]);
-    getConf().setStrings("input.pravega.scope", args[3]);
-    getConf().setStrings("input.pravega.stream", args[4]);
-    getConf().setStrings("input.pravega.output.stream.prefix", args[5]);
-    getConf().setStrings("input.pravega.deserializer", TextSerializer.class.getName());
+    getConf().setStrings(INPUT_URI_STRING, args[2]);
+    getConf().setStrings(INPUT_SCOPE_NAME, args[3]);
+    getConf().setStrings(INPUT_STREAM_NAME, args[4]);
+    getConf().setStrings(INPUT_DESERIALIZER, TextSerializer.class.getName());
+
+    getConf().setStrings(OUTPUT_SCOPE_NAME, args[3]);
+    getConf().setStrings(OUTPUT_URI_STRING, args[2]);
+    getConf().setStrings(OUTPUT_DESERIALIZER, TextSerializer.class.getName());
+    getConf().setStrings(OUTPUT_STREAM_PREFIX, args[5]);
+
     Job job = Job.getInstance(getConf());
 
     boolean useSimplePartitioner = getUseSimplePartitioner(job);

--- a/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/terasort/TeraStreamValidate.java
+++ b/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/terasort/TeraStreamValidate.java
@@ -37,6 +37,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import static io.pravega.connectors.hadoop.PravegaConfig.INPUT_DESERIALIZER;
+import static io.pravega.connectors.hadoop.PravegaConfig.INPUT_SCOPE_NAME;
+import static io.pravega.connectors.hadoop.PravegaConfig.INPUT_STREAM_NAME;
+import static io.pravega.connectors.hadoop.PravegaConfig.INPUT_URI_STRING;
+
 /**
  *  The class is to dump events from a Pravega stream into a hdfs file for manual validation
  *  of terasort results, e.g. checking whether events are sorted in a stream, as well as crossing streams.
@@ -61,10 +66,10 @@ public class TeraStreamValidate extends Configured implements Tool {
     LOG.info("starting");
     Path inputDir = new Path(args[0]);
     Path outputDir = new Path(args[1]);
-    getConf().setStrings("input.pravega.uri", args[2]);
-    getConf().setStrings("input.pravega.scope", args[3]);
-    getConf().setStrings("input.pravega.stream", args[4]);
-    getConf().setStrings("input.pravega.deserializer", TextSerializer.class.getName());
+    getConf().setStrings(INPUT_URI_STRING, args[2]);
+    getConf().setStrings(INPUT_SCOPE_NAME, args[3]);
+    getConf().setStrings(INPUT_STREAM_NAME, args[4]);
+    getConf().setStrings(INPUT_DESERIALIZER, TextSerializer.class.getName());
 
     getConf().setInt(MRJobConfig.NUM_MAPS, 1);
     Job job = Job.getInstance(getConf());

--- a/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/wordcount/WordCount.java
+++ b/hadoop-connector-examples/src/main/java/io/pravega/example/hadoop/wordcount/WordCount.java
@@ -10,6 +10,7 @@
 
 package io.pravega.example.hadoop.wordcount;
 
+import io.pravega.client.ClientConfig;
 import io.pravega.connectors.hadoop.PravegaInputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -26,6 +27,7 @@ import org.apache.hadoop.util.GenericOptionsParser;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.net.URI;
 import java.util.StringTokenizer;
 
 import org.slf4j.Logger;
@@ -135,7 +137,8 @@ public class WordCount {
         if (otherArgs.length >= 7) {
             endPos = otherArgs[6];
         } else {
-            endPos = PravegaInputFormat.fetchLatestPosition(uri, scope, stream);
+            ClientConfig clientConfig = ClientConfig.builder().controllerURI(URI.create(uri)).build();
+            endPos = PravegaInputFormat.fetchLatestPosition(clientConfig, scope, stream);
         }
         conf.setStrings("input.pravega.endpositions", endPos);
 

--- a/scenarios/anomaly-detection/build.gradle
+++ b/scenarios/anomaly-detection/build.gradle
@@ -23,19 +23,19 @@ sourceCompatibility = "1.8"
 archivesBaseName = 'pravega-flink-scenario-anomaly-detection'
 
 dependencies {
-    compile "io.pravega:pravega-connectors-flink_2.11:${flinkConnectorVersion}"
-    compile "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"
-    compile "org.apache.flink:flink-connector-elasticsearch5_2.11:${flinkVersion}"
+    compile "io.pravega:pravega-connectors-flink_$flinkScalaVersion:${flinkConnectorVersion}"
+    compile "org.apache.flink:flink-streaming-java_$flinkScalaVersion:${flinkVersion}"
+    compile "org.apache.flink:flink-connector-elasticsearch5_$flinkScalaVersion:${flinkVersion}"
     compile "ch.qos.logback:logback-classic:1.1.7"
 }
 
 shadowJar {
     dependencies {
-        include dependency("io.pravega:pravega-connectors-flink_2.11")
+        include dependency("io.pravega:pravega-connectors-flink_$flinkScalaVersion")
 
         //All below dependencies are from Elastic Search 5 connector
-        include dependency("org.apache.flink:flink-connector-elasticsearch5_2.11:${flinkVersion}")
-        include dependency("org.apache.flink:flink-connector-elasticsearch-base_2.11:${flinkVersion}")
+        include dependency("org.apache.flink:flink-connector-elasticsearch5_$flinkScalaVersion:${flinkVersion}")
+        include dependency("org.apache.flink:flink-connector-elasticsearch-base_$flinkScalaVersion:${flinkVersion}")
         include dependency("org.elasticsearch.client:transport:5.1.2")
         include dependency("org.elasticsearch:elasticsearch:5.1.2")
         include dependency("org.apache.lucene:lucene-core:6.3.0")

--- a/scenarios/pravega-flink-connector-sql-samples/build.gradle
+++ b/scenarios/pravega-flink-connector-sql-samples/build.gradle
@@ -23,10 +23,10 @@ sourceCompatibility = "1.8"
 archivesBaseName = 'pravega-flink-connector-sql-samples'
 
 dependencies {
-    compile "io.pravega:pravega-connectors-flink_2.11:${flinkConnectorVersion}"
-    compile "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"
-    compile "org.apache.flink:flink-table_2.11:${flinkVersion}"
-    compile "org.apache.flink:flink-streaming-scala_2.11:${flinkVersion}"
+    compile "io.pravega:pravega-connectors-flink_$flinkScalaVersion:${flinkConnectorVersion}"
+    compile "org.apache.flink:flink-streaming-java_$flinkScalaVersion:${flinkVersion}"
+    compile "org.apache.flink:flink-table_$flinkScalaVersion:${flinkVersion}"
+    compile "org.apache.flink:flink-streaming-scala_$flinkScalaVersion:${flinkVersion}"
     compile "ch.qos.logback:logback-classic:1.1.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.8.9"
 
@@ -64,6 +64,6 @@ distributions {
 
 shadowJar {
     dependencies {
-        include dependency("io.pravega:pravega-connectors-flink_2.11")
+        include dependency("io.pravega:pravega-connectors-flink_$flinkScalaVersion")
     }
 }

--- a/scenarios/turbine-heat-processor/build.gradle
+++ b/scenarios/turbine-heat-processor/build.gradle
@@ -21,22 +21,18 @@ apply plugin: 'eclipse'
 sourceCompatibility = "1.8"
 archivesBaseName = 'pravega-flink-scenario-turbineheatprocessor'
 
-ext {
-    scalaJava8CompatVersion = '0.7.0'
-}
-
 dependencies {
-    compile "org.scala-lang.modules:scala-java8-compat_2.11:${scalaJava8CompatVersion}"
-    compile "io.pravega:pravega-connectors-flink_2.11:${flinkConnectorVersion}"
-    compile "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"
-    compile "org.apache.flink:flink-streaming-scala_2.11:${flinkVersion}"
+    compile "org.scala-lang.modules:scala-java8-compat_$flinkScalaVersion:${scalaJava8CompatVersion}"
+    compile "io.pravega:pravega-connectors-flink_$flinkScalaVersion:${flinkConnectorVersion}"
+    compile "org.apache.flink:flink-streaming-java_$flinkScalaVersion:${flinkVersion}"
+    compile "org.apache.flink:flink-streaming-scala_$flinkScalaVersion:${flinkVersion}"
     compile "org.slf4j:slf4j-log4j12:1.7.14"
 }
 
 shadowJar {
     dependencies {
-        include dependency("org.scala-lang.modules:scala-java8-compat_2.11")
-        include dependency("io.pravega:pravega-connectors-flink_2.11")
+        include dependency("org.scala-lang.modules:scala-java8-compat_$flinkScalaVersion")
+        include dependency("io.pravega:pravega-connectors-flink_$flinkScalaVersion")
     }
 }
 

--- a/scenarios/turbine-heat-processor/src/main/java/io/pravega/turbineheatprocessor/TurbineHeatProcessor.java
+++ b/scenarios/turbine-heat-processor/src/main/java/io/pravega/turbineheatprocessor/TurbineHeatProcessor.java
@@ -45,6 +45,7 @@ public class TurbineHeatProcessor {
         // set up the streaming execution environment
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+        env.setParallelism(1); // required since on a multi core CPU machine, the watermark is not advancing due to idle sources and causing window not to trigger
 
         // 1. read and decode the sensor events from a Pravega stream
         FlinkPravegaReader<String> source = FlinkPravegaReader.<String>builder()

--- a/scenarios/turbine-heat-processor/src/main/scala/io/pravega/turbineheatprocessor/TurbineHeatProcessorScala.scala
+++ b/scenarios/turbine-heat-processor/src/main/scala/io/pravega/turbineheatprocessor/TurbineHeatProcessorScala.scala
@@ -80,6 +80,7 @@ object TurbineHeatProcessorScala {
     // set up the streaming execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1) // required since on a multi core CPU machine, the watermark is not advancing due to idle sources and causing window not to trigger
 
     // 1. read and decode the sensor events from a Pravega stream
     val source = FlinkPravegaReader.builder()


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

**Change log description**
  * Fixed guava library serialization issue
  * updated flink version to 1.7.2
  * updated pravega and Connector version to r0.5

**Purpose of the change**
To address https://github.com/pravega/pravega-samples/issues/197

**What the code does**
Updated samples to use Pravega and Connector artifacts from `r0.5` and fixed issues specific to Flink serialization with respect to the guava library.

**How to verify it**
Run `./gradlew clean installDist`  and test samples using the instructions from readme docs