### PR TITLE
Issue 212: Updated artifact versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,18 +8,18 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### Pravega dependencies
-pravegaVersion=0.5.0
+pravegaVersion=0.6.0-50.076afef-SNAPSHOT
 
 ### Pravega-samples output library
-samplesVersion=0.5.0
+samplesVersion=0.6.0-SNAPSHOT
 
 ### Flink-connector dependencies
-flinkConnectorVersion=0.5.0
+flinkConnectorVersion=0.6.0-62.452fcd4-SNAPSHOT
 flinkVersion=1.7.2
 flinkScalaVersion=2.12
 
 ### hadoop connector dependencies
-hadoopConnectorVersion=0.5.0
+hadoopConnectorVersion=0.6.0-33.1cfeee6-SNAPSHOT
 
 ### Samples application dependencies
 hadoopVersion=2.8.1


### PR DESCRIPTION
**Change log description**
Changed the `dev` branch `gradle.properties` artifacts of Pravega and Hadoop/Flink connectors to version latest available 0.6 artifacts. Changed samples version to `0.6.0-SNAPSHOT`.

**Purpose of the change**
Fixes #212.

**What the code does**
Upgrade the version of project dependency artifacts.

**How to verify it**
Clone the `dev` branch and execute `./gradlew installDist`, the build should be downloading the new dependencies and passing.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>