### PR TITLE
Issue 215: Build failed with latest Pravega version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,15 @@ allprojects {
 }
 
 subprojects {
+    if (file("src/main/java").isDirectory()) {
+        apply plugin: 'java'
+    dependencies {
+        compileOnly 'org.projectlombok:lombok:' + lombokVersion
+        testCompileOnly 'org.projectlombok:lombok:' + lombokVersion
+        annotationProcessor 'org.projectlombok:lombok:' + lombokVersion
+        testAnnotationProcessor 'org.projectlombok:lombok:' + lombokVersion
+        }
+    }
     repositories {
         mavenLocal()
         jcenter()
@@ -38,7 +47,7 @@ subprojects {
             url "https://oss.jfrog.org/jfrog-dependencies"
         }
     }
-    
+
     plugins.withType(org.gradle.api.plugins.JavaPlugin) {
         group "io.pravega"
         version samplesVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### Pravega dependencies
-pravegaVersion=0.5.0
+pravegaVersion=0.6.0-2397.5a60e36-SNAPSHOT
 
 ### Pravega-samples output library
 samplesVersion=0.5.0
@@ -27,3 +27,6 @@ kryoSerializerVersion=0.45
 sparkVersion=2.2.0
 scalaJava8CompatVersion=0.9.0
 slf4jLog4JVersion=1.7.25
+
+### lombok dependency
+lombokVersion=1.18.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip


### PR DESCRIPTION
**Changelog description**: 

- **Issue 4247** in _pravega/pravega_ removed _lombok_ and _netty-all_ from client's dependency list. So, added _lombok_ dependency (as the annotation processor ) in the _pravega-samples._
- **_Updated version_** of **gradle** in _gradle/wrapper/gradle-wrapper.properties_ .

**Purpose of the change**: 

- Fixes: #215  

**What the code does**: 

- Adds lombok dependency. 

**How to verify it:** 

- build must pass

_Please review @sachin-j-joshi _