### PR TITLE
Issue 233: Fix Flink samples build

### DIFF
--- a/flink-connector-examples/build.gradle
+++ b/flink-connector-examples/build.gradle
@@ -24,7 +24,6 @@ archivesBaseName = 'pravega-flink-examples'
 dependencies {
     compile "de.javakaffee:kryo-serializers:${kryoSerializerVersion}"
 
-    compile "io.pravega:pravega-client:${pravegaVersion}"
     compile "io.pravega:pravega-keycloak-client:${pravegaKeycloakVersion}"
 
     compile "org.scala-lang.modules:scala-java8-compat_${flinkScalaVersion}:${scalaJava8CompatVersion}"

--- a/scenarios/anomaly-detection/build.gradle
+++ b/scenarios/anomaly-detection/build.gradle
@@ -23,7 +23,6 @@ sourceCompatibility = "1.8"
 archivesBaseName = 'pravega-flink-scenario-anomaly-detection'
 
 dependencies {
-    compile "io.pravega:pravega-client:${pravegaVersion}"
     compile "io.pravega:pravega-keycloak-client:${pravegaKeycloakVersion}"
 
     compile "io.pravega:pravega-connectors-flink-${flinkMajorMinorVersion}_${flinkScalaVersion}:${flinkConnectorVersion}"

--- a/scenarios/pravega-flink-connector-sql-samples/build.gradle
+++ b/scenarios/pravega-flink-connector-sql-samples/build.gradle
@@ -23,7 +23,6 @@ sourceCompatibility = "1.8"
 archivesBaseName = 'pravega-flink-connector-sql-samples'
 
 dependencies {
-    compile "io.pravega:pravega-client:${pravegaVersion}"
     compile "io.pravega:pravega-keycloak-client:${pravegaKeycloakVersion}"
 
     compile "io.pravega:pravega-connectors-flink-${flinkMajorMinorVersion}_${flinkScalaVersion}:${flinkConnectorVersion}"

--- a/scenarios/turbine-heat-processor/build.gradle
+++ b/scenarios/turbine-heat-processor/build.gradle
@@ -22,7 +22,6 @@ sourceCompatibility = "1.8"
 archivesBaseName = 'pravega-flink-scenario-turbineheatprocessor'
 
 dependencies {
-    compile "io.pravega:pravega-client:${pravegaVersion}"
     compile "io.pravega:pravega-keycloak-client:${pravegaKeycloakVersion}"
 
     compile "org.scala-lang.modules:scala-java8-compat_${flinkScalaVersion}:${scalaJava8CompatVersion}"


### PR DESCRIPTION
**Change log description**
Removes the Pravega client from Flink build dependencies.

**Purpose of the change**
Fixes #233.

**What the code does**
According to @crazyzhou, 
>This bug is caused by the relocation of the io.grpc package. The return structure of the getClientInterceptor in flink connector is changed to io.pravega.shaded.io.grpc rather than io.grpc, causing the io.grpc return method not exist. See:
https://github.com/pravega/flink-connectors/blob/master/build.gradle#L157
It's a behaviour from the first commit of the repository. It was meant to shade the common libraries which could cause potential version conflicts with Flink.
My suggestion is to delete the pravega client dependency in the samples. See:
https://github.com/pravega/pravega-samples/blob/master/flink-connector-examples/build.gradle#L27
Tested in my environment that it's working fine. And we may also tell the users not to include both the connector and the client dependencies in the same project. This may cause conflicts like this

This PR just removes the Pravega client library from the Flink build to avoid the GPRC dependency conflict.

**How to verify it**
The build works and now the conflict has been removed.
