### PR TITLE
[issue-253] The help text and the code don't match

### DIFF
--- a/pravega-client-examples/src/main/java/io/pravega/example/consolerw/ConsoleWriter.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/consolerw/ConsoleWriter.java
@@ -48,7 +48,7 @@ public class ConsoleWriter implements AutoCloseable {
             "If no command is entered, the line is treated as a parameter to the WRITE_EVENT command.",
             "",
             "WRITE_EVENT {event} - write the {event} out to the Stream or the current Transaction.",
-            "WRITE_EVENT_RK <<{routingKey}>> , {event} - write the {event} out to the Stream or the current Transaction using {routingKey}. Note << and >> around {routingKey}.",
+            "WRITE_EVENT_RK ({routingKey}) {event} - write the {event} out to the Stream or the current Transaction using {routingKey}. Note ( and ) around {routingKey}.",
             "BEGIN - begin a Transaction. Only one Transaction at a time is supported by the CLI.",
             "GET_TXN_ID - output the current Transaction's Id (if a Transaction is running)",
             "FLUSH - flush the current Transaction (if a Transaction is running)",


### PR DESCRIPTION
Signed-off-by: Guangfeng Xu <Guangfeng.Xu@dell.com>

**Change log description**
The help text in  `ConsoleWriter` says that we should use `WRITE_EVENT_RK <<{routingKey}>> , {event}` to write the `{event}` out to the Stream or the current Transaction using `{routingKey}`. However, according to the code, the correct operation should be `WRITE_EVENT_RK ({routingKey}) {event}`. Change the help text to match the code.

**Purpose of the change**
Fixes #253

**What the code does**
Update the help text of ConsoleWriter.

**How to verify it**
Follow the `README.md` and the program should work.
