### PR TITLE
Issue 263: Prepare for 0.8 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,23 +8,23 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### Pravega dependencies
-pravegaVersion=0.8.0-2518.7685d8d-SNAPSHOT
-pravegaKeycloakVersion=0.7.0
+pravegaVersion=0.8.0
+pravegaKeycloakVersion=0.8.0
 
 ### Pravega-samples output library
-samplesVersion=0.8.0-SNAPSHOT
+samplesVersion=0.8.0
 
 ### Flink-connector dependencies
-flinkConnectorVersion=0.8.0-53.43f46fd-SNAPSHOT
-flinkVersion=1.10.0
+flinkConnectorVersion=0.8.0
+flinkVersion=1.10.2
 flinkMajorMinorVersion=1.10
 flinkScalaVersion=2.12
 
 ### hadoop connector dependencies
-hadoopConnectorVersion=0.7.0
+hadoopConnectorVersion=0.8.0
 
 ### schema registry sample dependencies
-schemaRegistryVersion=0.1.0-35.cea7bd1-SNAPSHOT
+schemaRegistryVersion=0.1.0
 commonsCliVersion=1.4
 
 ### Samples application dependencies

--- a/schema-registry-examples/build.gradle
+++ b/schema-registry-examples/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    compile "io.pravega.schemaregistry:serializers:${schemaRegistryVersion}"
+    compile "io.pravega:schemaregistry-serializers:${schemaRegistryVersion}"
     compile "commons-cli:commons-cli:${commonsCliVersion}"
 }
 


### PR DESCRIPTION
**Change log description**
Updated all artifact versions to 0.8.0 and Flink version to the latest one. Updated Schema Registry version to 0.1.0 and dependency name.

**Purpose of the change**
Fixes #263 and #261.

**What the code does**
Updates all artifact versions to 0.8.0 in `gradle.properties` with the exception of Schema Registry, which is in version 0.1.0. Also, fixed the dependency name of Schema Registry artifact. Flink version was updated to the last one (`1.10.2`).

**How to verify it**
`./gradlew clean installDist` should pass

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>