### PR TITLE
[issue-272] Remove the usage of PravegaSerialization

### DIFF
--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/process/ExactlyOnceChecker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/process/ExactlyOnceChecker.java
@@ -11,9 +11,10 @@
 package io.pravega.example.flink.primer.process;
 
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.PravegaConfig;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
 import io.pravega.example.flink.Utils;
 import io.pravega.example.flink.primer.datatype.Constants;
 import io.pravega.example.flink.primer.datatype.IntegerEvent;
@@ -67,7 +68,7 @@ public class ExactlyOnceChecker {
         FlinkPravegaReader<IntegerEvent> reader = FlinkPravegaReader.<IntegerEvent>builder()
                 .withPravegaConfig(pravegaConfig)
                 .forStream(stream)
-                .withDeserializationSchema(PravegaSerialization.deserializationFor(IntegerEvent.class))
+                .withDeserializationSchema(new PravegaDeserializationSchema<>(IntegerEvent.class, new JavaSerializer<>()))
                 .build();
 
         DataStream<IntegerEvent> dataStream = env

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/process/ExactlyOnceWriter.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/process/ExactlyOnceWriter.java
@@ -11,8 +11,9 @@
 package io.pravega.example.flink.primer.process;
 
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.*;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.connectors.flink.serialization.PravegaSerializationSchema;
 import io.pravega.example.flink.Utils;
 import io.pravega.example.flink.primer.datatype.IntegerEvent;
 import io.pravega.example.flink.primer.datatype.Constants;
@@ -83,7 +84,7 @@ public class ExactlyOnceWriter {
                 .withEventRouter( new EventRouter())
                 .withTxnLeaseRenewalPeriod(txnLeaseRenewalPeriod)
                 .withWriterMode( exactlyOnce ? PravegaWriterMode.EXACTLY_ONCE : PravegaWriterMode.ATLEAST_ONCE )
-                .withSerializationSchema(PravegaSerialization.serializationFor(IntegerEvent.class))
+                .withSerializationSchema(new PravegaSerializationSchema<>(new JavaSerializer<>()))
                 .build();
 
         env

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
@@ -15,11 +15,12 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.FlinkPravegaWriter;
 import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.connectors.flink.serialization.PravegaSerializationSchema;
 import io.pravega.example.flink.Utils;
 import io.pravega.example.flink.streamcuts.Constants;
 import io.pravega.example.flink.streamcuts.SensorStreamSlice;
@@ -86,7 +87,7 @@ public class StreamBookmarker {
         SinkFunction<SensorStreamSlice> writer = FlinkPravegaWriter.<SensorStreamSlice>builder()
                 .withPravegaConfig(pravegaConfig)
                 .forStream(streamCutsStream)
-                .withSerializationSchema(PravegaSerialization.serializationFor(SensorStreamSlice.class))
+                .withSerializationSchema(new PravegaSerializationSchema<>(new JavaSerializer<>()))
                 .withEventRouter(new EventRouter())
                 .build();
 

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/watermark/EventTimeAverage.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/watermark/EventTimeAverage.java
@@ -11,10 +11,12 @@
 package io.pravega.example.flink.watermark;
 
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.FlinkPravegaWriter;
 import io.pravega.connectors.flink.PravegaConfig;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
+import io.pravega.connectors.flink.serialization.PravegaSerializationSchema;
 import io.pravega.connectors.flink.watermark.LowerBoundAssigner;
 import io.pravega.example.flink.Utils;
 import org.apache.flink.api.common.functions.AggregateFunction;
@@ -74,7 +76,7 @@ public class EventTimeAverage {
         FlinkPravegaReader<SensorData> source = FlinkPravegaReader.<SensorData>builder()
                 .withPravegaConfig(pravegaConfig)
                 .forStream(inputStream)
-                .withDeserializationSchema(PravegaSerialization.deserializationFor(SensorData.class))
+                .withDeserializationSchema(new PravegaDeserializationSchema<>(SensorData.class, new JavaSerializer<>()))
                 // provide an implementation of AssignerWithTimeWindows<T>
                 .withTimestampAssigner(new LowerBoundAssigner<SensorData>() {
                     @Override
@@ -104,7 +106,7 @@ public class EventTimeAverage {
                 // enable watermark propagation
                 .enableWatermark(true)
                 .withEventRouter(event -> String.valueOf(event.getSensorId()))
-                .withSerializationSchema(PravegaSerialization.serializationFor(SensorData.class))
+                .withSerializationSchema(new PravegaSerializationSchema<>(new JavaSerializer<>()))
                 .build();
 
         // Print to pravega sink for further usage

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/wordcount/WordCountReader.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/wordcount/WordCountReader.java
@@ -13,9 +13,9 @@ package io.pravega.example.flink.wordcount;
 import io.pravega.client.stream.Stream;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.PravegaConfig;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
 import io.pravega.example.flink.Utils;
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -67,7 +67,7 @@ public class WordCountReader {
         FlinkPravegaReader<String> source = FlinkPravegaReader.<String>builder()
                 .withPravegaConfig(pravegaConfig)
                 .forStream(stream)
-                .withDeserializationSchema(PravegaSerialization.deserializationFor(String.class))
+                .withDeserializationSchema(new SimpleStringSchema())
                 .build();
 
         // count each word over a 10 second time period

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/wordcount/WordCountWriter.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/wordcount/WordCountWriter.java
@@ -15,8 +15,8 @@ import io.pravega.client.stream.Stream;
 import io.pravega.connectors.flink.FlinkPravegaWriter;
 import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
 import io.pravega.example.flink.Utils;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +78,7 @@ public class WordCountWriter {
                 .withPravegaConfig(pravegaConfig)
                 .forStream(stream)
                 .withEventRouter(new EventRouter())
-                .withSerializationSchema(PravegaSerialization.serializationFor(String.class))
+                .withSerializationSchema(new SimpleStringSchema())
                 .build();
         dataStream.addSink(writer).name("Pravega Stream");
 

--- a/scenarios/anomaly-detection/src/main/java/io/pravega/anomalydetection/event/pipeline/PravegaAnomalyDetectionProcessor.java
+++ b/scenarios/anomaly-detection/src/main/java/io/pravega/anomalydetection/event/pipeline/PravegaAnomalyDetectionProcessor.java
@@ -14,9 +14,10 @@ import io.pravega.anomalydetection.event.AppConfiguration;
 import io.pravega.anomalydetection.event.state.Event;
 import io.pravega.anomalydetection.event.state.Result;
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.PravegaConfig;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
 import io.pravega.shaded.com.google.gson.Gson;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
@@ -52,7 +53,7 @@ public class PravegaAnomalyDetectionProcessor extends AbstractPipeline {
 		FlinkPravegaReader<Event> flinkPravegaReader = FlinkPravegaReader.<Event>builder()
 				.withPravegaConfig(getPravegaConfig())
 				.forStream(getStreamId())
-				.withDeserializationSchema(PravegaSerialization.deserializationFor(Event.class))
+				.withDeserializationSchema(new PravegaDeserializationSchema<>(Event.class, new JavaSerializer<>()))
 				.build();
 
 		// Configure the Flink job environment

--- a/scenarios/anomaly-detection/src/main/java/io/pravega/anomalydetection/event/pipeline/PravegaEventPublisher.java
+++ b/scenarios/anomaly-detection/src/main/java/io/pravega/anomalydetection/event/pipeline/PravegaEventPublisher.java
@@ -15,10 +15,11 @@ import io.pravega.anomalydetection.event.producer.ControlledSourceContextProduce
 import io.pravega.anomalydetection.event.producer.SourceContextProducer;
 import io.pravega.anomalydetection.event.state.Event;
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.FlinkPravegaWriter;
 import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.PravegaEventRouter;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.connectors.flink.serialization.PravegaSerializationSchema;
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
@@ -41,7 +42,7 @@ public class PravegaEventPublisher extends AbstractPipeline {
 		FlinkPravegaWriter<Event> writer = FlinkPravegaWriter.<Event>builder()
 				.withPravegaConfig(getPravegaConfig())
 				.forStream(stream)
-				.withSerializationSchema(PravegaSerialization.serializationFor(Event.class))
+				.withSerializationSchema(new PravegaSerializationSchema<>(new JavaSerializer<>()))
 				.withEventRouter(new EventRouter())
 				.build();
 

--- a/scenarios/turbine-heat-processor/src/main/java/io/pravega/turbineheatprocessor/TurbineHeatProcessor.java
+++ b/scenarios/turbine-heat-processor/src/main/java/io/pravega/turbineheatprocessor/TurbineHeatProcessor.java
@@ -13,9 +13,10 @@ package io.pravega.turbineheatprocessor;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.PravegaConfig;
-import io.pravega.connectors.flink.serialization.PravegaSerialization;
+import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -51,7 +52,7 @@ public class TurbineHeatProcessor {
         FlinkPravegaReader<String> source = FlinkPravegaReader.<String>builder()
                 .withPravegaConfig(pravegaConfig)
                 .forStream(stream)
-                .withDeserializationSchema(PravegaSerialization.deserializationFor(String.class))
+                .withDeserializationSchema(new PravegaDeserializationSchema<>(String.class, new JavaSerializer<>()))
                 .build();
         DataStream<SensorEvent> events = env.addSource(source, "input").map(new SensorMapper()).name("events");
 

--- a/scenarios/turbine-heat-processor/src/main/scala/io/pravega/turbineheatprocessor/TurbineHeatProcessorScala.scala
+++ b/scenarios/turbine-heat-processor/src/main/scala/io/pravega/turbineheatprocessor/TurbineHeatProcessorScala.scala
@@ -10,8 +10,9 @@
  */
 package io.pravega.turbineheatprocessor;
 
+import io.pravega.client.stream.impl.JavaSerializer
 import io.pravega.client.stream.{ScalingPolicy, StreamConfiguration}
-import io.pravega.connectors.flink.serialization.PravegaSerialization
+import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema
 import io.pravega.connectors.flink.{FlinkPravegaReader, PravegaConfig}
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.core.fs.FileSystem
@@ -86,7 +87,7 @@ object TurbineHeatProcessorScala {
     val source = FlinkPravegaReader.builder()
       .withPravegaConfig(pravegaConfig)
       .forStream(stream)
-      .withDeserializationSchema(PravegaSerialization.deserializationFor(classOf[String]))
+      .withDeserializationSchema(new PravegaDeserializationSchema(classOf[String], new JavaSerializer[String]()))
       .build()
 
     val events: DataStream[SensorEvent] = env.addSource(source).name("input").map { line =>


### PR DESCRIPTION
**Change log description**
Update serialization classes in Flink samples.

**Purpose of the change**
Fixes #272 

**What the code does**
Replaces the following deprecated occurrences for serialization in Flink samples:
- `PravegaSerialization.deserializationFor` -> `new PravegaDeserializationSchema<>(xxx.class, new JavaSerializer<>())`
- `PravegaSerialization.serializationFor` -> `new PravegaSerializationSchema<>(new JavaSerializer<>())`

**How to verify it**
Flink samples build and work with this change.
