### PR TITLE
[issue-273] Upgrade to Flink 1.11 and update the Flink SQL sample

### DIFF
--- a/flink-connector-examples/build.gradle
+++ b/flink-connector-examples/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile "org.scala-lang.modules:scala-java8-compat_${flinkScalaVersion}:${scalaJava8CompatVersion}"
     compile "io.pravega:pravega-connectors-flink-${flinkMajorMinorVersion}_${flinkScalaVersion}:${flinkConnectorVersion}"
     compile "org.apache.flink:flink-streaming-java_${flinkScalaVersion}:${flinkVersion}"
-    compile "org.apache.flink:flink-streaming-scala_${flinkScalaVersion}:${flinkVersion}"
+    compile "org.apache.flink:flink-clients_${flinkScalaVersion}:${flinkVersion}"
 
     compile "org.slf4j:slf4j-log4j12:${slf4jLog4JVersion}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,9 @@ pravegaKeycloakVersion=0.8.0
 samplesVersion=0.8.0
 
 ### Flink-connector dependencies
-flinkConnectorVersion=0.8.0
-flinkVersion=1.10.2
-flinkMajorMinorVersion=1.10
+flinkConnectorVersion=0.9.0-50.e9d5a98-SNAPSHOT
+flinkVersion=1.11.2
+flinkMajorMinorVersion=1.11
 flinkScalaVersion=2.12
 
 ### hadoop connector dependencies

--- a/scenarios/anomaly-detection/build.gradle
+++ b/scenarios/anomaly-detection/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
     compile "io.pravega:pravega-connectors-flink-${flinkMajorMinorVersion}_${flinkScalaVersion}:${flinkConnectorVersion}"
     compile "org.apache.flink:flink-streaming-java_${flinkScalaVersion}:${flinkVersion}"
+    compile "org.apache.flink:flink-clients_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-connector-elasticsearch5_${flinkScalaVersion}:${flinkVersion}"
     compile "ch.qos.logback:logback-classic:1.1.7"
 }

--- a/scenarios/pravega-flink-connector-sql-samples/build.gradle
+++ b/scenarios/pravega-flink-connector-sql-samples/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile "org.apache.flink:flink-streaming-java_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-table-planner_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-table-api-java-bridge_${flinkScalaVersion}:${flinkVersion}"
-    compile "org.apache.flink:flink-streaming-scala_${flinkScalaVersion}:${flinkVersion}"
+    compile "org.apache.flink:flink-clients_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-json:${flinkVersion}"
     compile "org.apache.flink:flink-table-planner-blink_${flinkScalaVersion}:${flinkVersion}"
 

--- a/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/AbstractHandler.java
+++ b/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/AbstractHandler.java
@@ -73,5 +73,41 @@ public abstract class AbstractHandler {
         return env;
     }
 
+    public String createTableDdl(String watermarkDdl, String readerGroupName) {
+        return String.format(
+                "CREATE TABLE TaxiRide (%n" +
+                        "  rideId INT,%n" +
+                        "  vendorId INT,%n" +
+                        "  pickupTime TIMESTAMP(3),%n" +
+                        "  dropOffTime TIMESTAMP(3),%n" +
+                        "  passengerCount INT,%n" +
+                        "  tripDistance FLOAT,%n" +
+                        "  startLocationId INT,%n" +
+                        "  destLocationId INT,%n" +
+                        "  startLocationBorough STRING,%n" +
+                        "  startLocationZone STRING,%n" +
+                        "  startLocationServiceZone STRING,%n" +
+                        "  destLocationBorough STRING,%n" +
+                        "  destLocationZone STRING,%n" +
+                        "  destLocationServiceZone STRING,%n" +
+                        "  %s" +
+                        ") with (%n" +
+                        "  'connector' = 'pravega',%n" +
+                        "  'controller-uri' = '%s',%n" +
+                        "  'scope' = '%s',%n" +
+                        "  'scan.execution.type' = '%s',%n" +
+                        "  'scan.reader-group.name' = '%s',%n" +
+                        "  'scan.streams' = '%s',%n" +
+                        "  'format' = 'json'%n" +
+                        ")",
+                watermarkDdl,
+                controllerUri,
+                scope,
+                "streaming",
+                readerGroupName,
+                stream,
+                stream);
+    }
+
     public abstract void handleRequest();
 }

--- a/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/MaxTravellersPerDestination.java
+++ b/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/MaxTravellersPerDestination.java
@@ -10,18 +10,15 @@
  */
 package io.pravega.connectors.nytaxi;
 
-import io.pravega.client.stream.Stream;
-import io.pravega.connectors.flink.table.descriptors.Pravega;
-import io.pravega.connectors.nytaxi.common.TripRecord;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.Tumble;
-import org.apache.flink.table.descriptors.Json;
-import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.types.Row;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.lit;
 
 /**
  * Find maximum number of travellers who travelled to a destination point for a given window interval.
@@ -37,38 +34,18 @@ public class MaxTravellersPerDestination extends AbstractHandler {
     @Override
     public void handleRequest() {
 
-        Schema schema = TripRecord.getSchemaWithDropOffTimeAsRowTime();
-
         StreamExecutionEnvironment env = getStreamExecutionEnvironment();
 
         // create a TableEnvironment
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(
-                env,
-                EnvironmentSettings.newInstance()
-                        .useBlinkPlanner()
-                        .inStreamingMode()
-                        .build()
-        );
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
-        Pravega pravega = new Pravega();
-        pravega.tableSourceReaderBuilder()
-                .forStream(Stream.of(getScope(), getStream()).getScopedName())
-                .withPravegaConfig(getPravegaConfig());
-
-        tEnv.connect(pravega)
-                .withFormat(new Json().failOnMissingField(true))
-                .withSchema(schema)
-                .inAppendMode()
-                .registerTableSource("TaxiRide");
-
-        String fields = "passengerCount, dropOffTime, destLocationZone";
+        tEnv.executeSql(createTableDdl("WATERMARK FOR dropOffTime AS dropOffTime - INTERVAL '30' SECONDS", "max-traveller"));
 
         Table noOfTravelersPerDest = tEnv
-                .from("TaxiRide")
-                .select(fields)
-                .window(Tumble.over("1.hour").on("dropOffTime").as("w"))
-                .groupBy("destLocationZone, w")
-                .select("destLocationZone, w.start AS start, w.end AS end, count(passengerCount) AS cnt");
+                .from("TaxiRide").select($("passengerCount"), $("dropOffTime"), $("destLocationZone"))
+                .window(Tumble.over(lit(1).hour()).on($("dropOffTime")).as("w"))
+                .groupBy($("destLocationZone"), $("w"))
+                .select($("destLocationZone"), $("w").start().as("start"), $("w").end().as("end"), $("passengerCount").count().as("cnt"));
 
         tEnv.toAppendStream(noOfTravelersPerDest, Row.class).print();
 

--- a/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/MaxTravellersPerDestination.java
+++ b/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/MaxTravellersPerDestination.java
@@ -42,7 +42,8 @@ public class MaxTravellersPerDestination extends AbstractHandler {
         tEnv.executeSql(createTableDdl("WATERMARK FOR dropOffTime AS dropOffTime - INTERVAL '30' SECONDS", "max-traveller"));
 
         Table noOfTravelersPerDest = tEnv
-                .from("TaxiRide").select($("passengerCount"), $("dropOffTime"), $("destLocationZone"))
+                .from("TaxiRide")
+                .select($("passengerCount"), $("dropOffTime"), $("destLocationZone"))
                 .window(Tumble.over(lit(1).hour()).on($("dropOffTime")).as("w"))
                 .groupBy($("destLocationZone"), $("w"))
                 .select($("destLocationZone"), $("w").start().as("start"), $("w").end().as("end"), $("passengerCount").count().as("cnt"));

--- a/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/PopularTaxiVendor.java
+++ b/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/PopularTaxiVendor.java
@@ -10,18 +10,15 @@
  */
 package io.pravega.connectors.nytaxi;
 
-import io.pravega.client.stream.Stream;
-import io.pravega.connectors.flink.table.descriptors.Pravega;
-import io.pravega.connectors.nytaxi.common.TripRecord;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.Slide;
-import org.apache.flink.table.api.java.StreamTableEnvironment;
-import org.apache.flink.table.descriptors.Json;
-import org.apache.flink.table.descriptors.Schema;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.lit;
 
 /**
  * Identify the popular taxi vendor based on total trips travelled on specific window interval.
@@ -37,38 +34,19 @@ public class PopularTaxiVendor extends AbstractHandler {
     @Override
     public void handleRequest() {
 
-        Schema schema = TripRecord.getSchemaWithPickupTimeAsRowTime();
-
         StreamExecutionEnvironment env = getStreamExecutionEnvironment();
 
         // create a TableEnvironment
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(
-                env,
-                EnvironmentSettings.newInstance()
-                        .useBlinkPlanner()
-                        .inStreamingMode()
-                        .build()
-        );
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
-        Pravega pravega = new Pravega();
-        pravega.tableSourceReaderBuilder()
-                .forStream(Stream.of(getScope(), getStream()).getScopedName())
-                .withPravegaConfig(getPravegaConfig());
-
-        tEnv.connect(pravega)
-                .withFormat(new Json().failOnMissingField(true))
-                .withSchema(schema)
-                .inAppendMode()
-                .registerTableSource("TaxiRide");
-
-        String fields = "vendorId, pickupTime, startLocationId, destLocationId, startLocationBorough, startLocationZone, destLocationBorough, destLocationZone";
+        tEnv.executeSql(createTableDdl("WATERMARK FOR pickupTime AS pickupTime - INTERVAL '30' SECONDS", "popular-vendor"));
 
         Table popularRides = tEnv
                 .from("TaxiRide")
-                .select(fields)
-                .window(Slide.over("15.minutes").every("5.minutes").on("pickupTime").as("w"))
-                .groupBy("vendorId, w")
-                .select("vendorId, w.start AS start, w.end AS end, count(vendorId) AS cnt");
+                .select($("vendorId"), $("pickupTime"))
+                .window(Slide.over(lit(15).minutes()).every(lit(5).minutes()).on($("pickupTime")).as("w"))
+                .groupBy($("vendorId"), $("w"))
+                .select($("vendorId"), $("w").start().as("start"), $("w").end().as("end"), $("vendorId").count().as("cnt"));
 
         tEnv.toAppendStream(popularRides, Row.class).print();
 

--- a/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/PrepareMain.java
+++ b/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/PrepareMain.java
@@ -48,7 +48,7 @@ public class PrepareMain extends AbstractHandler {
                 .withPravegaConfig(getPravegaConfig())
                 .forStream(streamInfo)
                 .withSerializationSchema(new PravegaSerializationSchema<>(new JsonSerializer<>(TripRecord.class)))
-                .withEventRouter(r -> String.valueOf(r.getRideId()))
+                .withEventRouter(r -> String.valueOf(r.getStartLocationId()))
                 .build();
 
         StreamExecutionEnvironment env = getStreamExecutionEnvironment();

--- a/scenarios/turbine-heat-processor/build.gradle
+++ b/scenarios/turbine-heat-processor/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compile "io.pravega:pravega-connectors-flink-${flinkMajorMinorVersion}_${flinkScalaVersion}:${flinkConnectorVersion}"
     compile "org.apache.flink:flink-streaming-java_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-streaming-scala_${flinkScalaVersion}:${flinkVersion}"
+    compile "org.apache.flink:flink-clients_${flinkScalaVersion}:${flinkVersion}"
 
     compile "org.slf4j:slf4j-log4j12:1.7.14"
 }


### PR DESCRIPTION
Signed-off-by: Brian Zhou <b.zhou@dell.com>

**Changes:**
This PR makes the following changes:
- Upgrade Flink connector to `0.9.0-50.e9d5a98-SNAPSHOT`
- Upgrade to Flink `1.11.2`
- Add `flink-clients_2.12` dependency to all Flink samples because it is required, mentioned in Flink 1.11 release notes [here](https://ci.apache.org/projects/flink/flink-docs-stable/release-notes/flink-1.11.html#reversed-dependency-from-flink-streaming-java-to-flink-client-flink-15090)
- Update the SQL sample to remove deprecate usages including
  - Use DDL to create table to connect with Pravega stream, this uses the new Table API
  - Use string to store json format timestamp, which is recommended in [official doc](https://ci.apache.org/projects/flink/flink-docs-release-1.11/dev/table/connectors/formats/json.html#data-type-mapping)
  - Use `$()` style `Expression` for SQL queries to replace the deprecated usage of direct String.
  - Remove the redundant `Row` transformation in data injection

**Testing:**
Build passes.
```
BUILD SUCCESSFUL in 1m 41s
```

Test output with new SQL example.
```
// max traveller
"Midtown East",2018-01-30T17:00,2018-01-30T18:00,1
"East Chelsea",2018-01-30T17:00,2018-01-30T18:00,1
"Sutton Place/Turtle Bay North",2018-01-30T18:00,2018-01-30T19:00,2
...

// popular destination query
236,2018-01-30T17:50,2018-01-30T18:05,27
237,2018-01-30T17:50,2018-01-30T18:05,26
236,2018-01-30T18:50,2018-01-30T19:05,24
...

// popular taxi vendor
1,2018-01-30T17:15,2018-01-30T17:30,1
2,2018-01-30T17:15,2018-01-30T17:30,1
2,2018-01-30T17:20,2018-01-30T17:35,1
1,2018-01-30T17:20,2018-01-30T17:35,1
1,2018-01-30T17:25,2018-01-30T17:40,1
2,2018-01-30T17:40,2018-01-30T17:55,1
2,2018-01-30T17:45,2018-01-30T18:00,92
1,2018-01-30T17:45,2018-01-30T18:00,69
2,2018-01-30T17:50,2018-01-30T18:05,261
1,2018-01-30T17:50,2018-01-30T18:05,191
...
```