### PR TITLE
Issue 276: Prepare for 0.9 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,29 +8,29 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### Pravega dependencies
-pravegaVersion=0.8.0
-pravegaKeycloakVersion=0.8.0
+pravegaVersion=0.9.0
+pravegaKeycloakVersion=0.9.0
 
 ### Pravega-samples output library
-samplesVersion=0.8.0
+samplesVersion=0.9.0
 
 ### Flink-connector dependencies
-flinkConnectorVersion=0.9.0-50.e9d5a98-SNAPSHOT
+flinkConnectorVersion=0.9.0
 flinkVersion=1.11.2
 flinkMajorMinorVersion=1.11
 flinkScalaVersion=2.12
 
 ### hadoop connector dependencies
-hadoopConnectorVersion=0.8.0
+hadoopConnectorVersion=0.9.0
 
 ### schema registry sample dependencies
-schemaRegistryVersion=0.1.0
+schemaRegistryVersion=0.2.0
 commonsCliVersion=1.4
 
 ### Spark connector dependencies
 scalaVersion=2.11.8
 sparkVersion=2.4.6
-sparkConnectorVersion=0.8.0-SNAPSHOT
+sparkConnectorVersion=0.9.0
 
 ### Samples application dependencies
 hadoopVersion=2.8.1

--- a/schema-registry-examples/build.gradle
+++ b/schema-registry-examples/build.gradle
@@ -33,6 +33,7 @@ repositories {
 }
 
 dependencies {
+    compile "io.pravega:pravega-client:${pravegaVersion}"
     compile "io.pravega:schemaregistry-serializers:${schemaRegistryVersion}"
     compile "commons-cli:commons-cli:${commonsCliVersion}"
 }

--- a/schema-registry-examples/src/main/java/io/pravega/schemaregistry/samples/codec/CompressionDemo.java
+++ b/schema-registry-examples/src/main/java/io/pravega/schemaregistry/samples/codec/CompressionDemo.java
@@ -51,8 +51,8 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Base64;
@@ -91,7 +91,7 @@ public class CompressionDemo {
         }
 
         @Override
-        public void encode(ByteBuffer data, ByteArrayOutputStream bos) throws IOException {
+        public void encode(ByteBuffer data, OutputStream bos) throws IOException {
             // left rotate by 1 byte
             byte[] array = new byte[data.remaining()];
             data.get(array);


### PR DESCRIPTION
**Change log description**
Updated all artifact versions to 0.9.0. Updated Schema Registry version to 0.2.0, added Pravega client dependency and fixed one API call signature.

**Purpose of the change**
Fixes #276.

**What the code does**
Updates all artifact versions to 0.9.0 in `gradle.properties` with the exception of Schema Registry, which is in version 0.2.0. Also, added the Pravega client dependency in Schema Registry and fixed one API call signature in a sample.

**How to verify it**
`./gradlew clean installDist` should pass

Signed-off-by: Raúl <raul.gracia@emc.com>