### PR TITLE
Issue 283: Update Spark examples to be compatible with SDP

### DIFF
--- a/spark-connector-examples/src/main/python/batch_file_to_pravega.py
+++ b/spark-connector-examples/src/main/python/batch_file_to_pravega.py
@@ -9,8 +9,9 @@
 from pyspark.sql import SparkSession
 import os
 
-controller = os.getenv("PRAVEGA_CONTROLLER", "tcp://127.0.0.1:9090")
+controller = os.getenv("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
 scope = os.getenv("PRAVEGA_SCOPE", "examples")
+allowCreateScope = os.getenv("PROJECT_NAME") is None
 filename = "sample_data.json"
 
 spark = (SparkSession
@@ -33,6 +34,7 @@ df.show(20, truncate=False)
 (df
     .write
     .format("pravega")
+    .option("allow_create_scope", allowCreateScope)
     .option("controller", controller)
     .option("scope", scope)
     .option("stream", "batchstream1")

--- a/spark-connector-examples/src/main/python/batch_pravega_to_console.py
+++ b/spark-connector-examples/src/main/python/batch_pravega_to_console.py
@@ -9,8 +9,9 @@
 from pyspark.sql import SparkSession
 import os
 
-controller = os.getenv("PRAVEGA_CONTROLLER", "tcp://127.0.0.1:9090")
+controller = os.getenv("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
 scope = os.getenv("PRAVEGA_SCOPE", "examples")
+allowCreateScope = os.getenv("PROJECT_NAME") is None
 
 spark = (SparkSession
          .builder
@@ -20,7 +21,8 @@ spark = (SparkSession
 df = (spark
     .read
     .format("pravega") 
-    .option("controller", controller) 
+    .option("allow_create_scope", allowCreateScope)
+    .option("controller", controller)
     .option("scope", scope) 
     .option("stream", "batchstream1")
     .load()

--- a/spark-connector-examples/src/main/python/stream_bounded_pravega_to_console.py
+++ b/spark-connector-examples/src/main/python/stream_bounded_pravega_to_console.py
@@ -9,8 +9,10 @@
 from pyspark.sql import SparkSession
 import os
 
-controller = os.getenv("PRAVEGA_CONTROLLER", "tcp://127.0.0.1:9090")
+controller = os.getenv("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
 scope = os.getenv("PRAVEGA_SCOPE", "examples")
+allowCreateScope = os.getenv("PROJECT_NAME") is None
+checkPointLocation = os.getenv("CHECKPOINT_DIR", "/tmp/spark-checkpoints-stream_bounded_pravega_to_console")
 
 spark = (SparkSession
          .builder
@@ -20,7 +22,8 @@ spark = (SparkSession
 (spark 
     .readStream 
     .format("pravega") 
-    .option("controller", controller) 
+    .option("allow_create_scope", allowCreateScope)
+    .option("controller", controller)
     .option("scope", scope) 
     .option("stream", "streamprocessing1")
     # If there is no checkpoint, start at the earliest event.
@@ -34,7 +37,7 @@ spark = (SparkSession
     .outputMode("append") 
     .format("console")
     .option("truncate", "false")
-    .option("checkpointLocation", "/tmp/spark-checkpoints-stream_bounded_pravega_to_console")
+    .option("checkpointLocation", checkPointLocation)
     .start() 
     .awaitTermination()
  )

--- a/spark-connector-examples/src/main/python/stream_generated_data_to_pravega.py
+++ b/spark-connector-examples/src/main/python/stream_generated_data_to_pravega.py
@@ -9,8 +9,10 @@
 from pyspark.sql import SparkSession
 import os
 
-controller = os.getenv("PRAVEGA_CONTROLLER", "tcp://127.0.0.1:9090")
+controller = os.getenv("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
 scope = os.getenv("PRAVEGA_SCOPE", "examples")
+allowCreateScope = os.getenv("PROJECT_NAME") is None
+checkPointLocation = os.getenv("CHECKPOINT_DIR", "/tmp/spark-checkpoints-stream_generated_data_to_pravega")
 
 spark = (SparkSession
          .builder
@@ -26,10 +28,11 @@ spark = (SparkSession
     .trigger(processingTime="3 seconds") 
     .outputMode("append") 
     .format("pravega") 
-    .option("controller", controller) 
+    .option("allow_create_scope", allowCreateScope)
+    .option("controller", controller)
     .option("scope", scope) 
     .option("stream", "streamprocessing1") 
-    .option("checkpointLocation", "/tmp/spark-checkpoints-stream_generated_data_to_pravega") 
+    .option("checkpointLocation", checkPointLocation)
     .start() 
     .awaitTermination()
  )

--- a/spark-connector-examples/src/main/python/stream_pravega_to_console.py
+++ b/spark-connector-examples/src/main/python/stream_pravega_to_console.py
@@ -9,8 +9,10 @@
 from pyspark.sql import SparkSession
 import os
 
-controller = os.getenv("PRAVEGA_CONTROLLER", "tcp://127.0.0.1:9090")
+controller = os.getenv("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
 scope = os.getenv("PRAVEGA_SCOPE", "examples")
+allowCreateScope = os.getenv("PROJECT_NAME") is None
+checkPointLocation = os.getenv("CHECKPOINT_DIR", "/tmp/spark-checkpoints-stream_pravega_to_console")
 
 spark = (SparkSession
          .builder
@@ -20,7 +22,8 @@ spark = (SparkSession
 (spark 
     .readStream 
     .format("pravega") 
-    .option("controller", controller) 
+    .option("allow_create_scope", allowCreateScope)
+    .option("controller", controller)
     .option("scope", scope) 
     .option("stream", "streamprocessing1")
     # If there is no checkpoint, start at the earliest event.
@@ -32,7 +35,7 @@ spark = (SparkSession
     .outputMode("append") 
     .format("console")
     .option("truncate", "false")
-    .option("checkpointLocation", "/tmp/spark-checkpoints-stream_pravega_to_console")
+    .option("checkpointLocation", checkPointLocation)
     .start() 
     .awaitTermination()
  )

--- a/spark-connector-examples/src/main/python/stream_pravega_to_pravega.py
+++ b/spark-connector-examples/src/main/python/stream_pravega_to_pravega.py
@@ -9,8 +9,10 @@
 from pyspark.sql import SparkSession
 import os
 
-controller = os.getenv("PRAVEGA_CONTROLLER", "tcp://127.0.0.1:9090")
+controller = os.getenv("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
 scope = os.getenv("PRAVEGA_SCOPE", "examples")
+allowCreateScope = os.getenv("PROJECT_NAME") is None
+checkPointLocation = os.getenv("CHECKPOINT_DIR", "/tmp/spark-checkpoints-stream_pravega_to_pravega")
 
 spark = (SparkSession
          .builder
@@ -20,7 +22,8 @@ spark = (SparkSession
 (spark
     .readStream 
     .format("pravega") 
-    .option("controller", controller) 
+    .option("allow_create_scope", allowCreateScope)
+    .option("controller", controller)
     .option("scope", scope) 
     .option("stream", "streamprocessing1")
     # If there is no checkpoint, start at the earliest event.
@@ -34,7 +37,7 @@ spark = (SparkSession
     .option("controller", controller) 
     .option("scope", scope) 
     .option("stream", "streamprocessing2") 
-    .option("checkpointLocation", "/tmp/spark-checkpoints-stream_pravega_to_pravega") 
+    .option("checkpointLocation", checkPointLocation)
     .start() 
     .awaitTermination()
  )

--- a/spark-connector-examples/src/main/scala/io/pravega/example/spark/StreamPravegaToConsole.scala
+++ b/spark-connector-examples/src/main/scala/io/pravega/example/spark/StreamPravegaToConsole.scala
@@ -20,13 +20,14 @@ object StreamPravegaToConsole {
       .getOrCreate()
 
     val scope = sys.env.getOrElse("PRAVEGA_SCOPE", "examples")
+    val allowCreateScope = !sys.env.contains("PROJECT_NAME")
     val controller = sys.env.getOrElse("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
     val checkpointLocation = sys.env.getOrElse("CHECKPOINT_DIR", "/tmp/spark-checkpoints-StreamPravegaToConsole")
 
     spark
       .readStream
       .format("pravega")
-      .option("allow_create_scope", "false")
+      .option("allow_create_scope", allowCreateScope)
       .option("controller", controller)
       .option("scope", scope)
       .option("stream", "streamprocessing1")

--- a/spark-connector-examples/src/main/scala/io/pravega/example/spark/StreamPravegaToConsole.scala
+++ b/spark-connector-examples/src/main/scala/io/pravega/example/spark/StreamPravegaToConsole.scala
@@ -20,11 +20,13 @@ object StreamPravegaToConsole {
       .getOrCreate()
 
     val scope = sys.env.getOrElse("PRAVEGA_SCOPE", "examples")
-    val controller = sys.env.getOrElse("PRAVEGA_CONTROLLER", "tcp://127.0.0.1:9090")
+    val controller = sys.env.getOrElse("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
+    val checkpointLocation = sys.env.getOrElse("CHECKPOINT_DIR", "/tmp/spark-checkpoints-StreamPravegaToConsole")
 
     spark
       .readStream
       .format("pravega")
+      .option("allow_create_scope", "false")
       .option("controller", controller)
       .option("scope", scope)
       .option("stream", "streamprocessing1")
@@ -37,7 +39,7 @@ object StreamPravegaToConsole {
       .outputMode("append")
       .format("console")
       .option("truncate", "false")
-      .option("checkpointLocation", "/tmp/spark-checkpoints-StreamPravegaToConsole")
+      .option("checkpointLocation", checkpointLocation)
       .start()
       .awaitTermination()
   }

--- a/spark-connector-examples/src/main/scala/io/pravega/example/spark/StreamPravegaToPravega.scala
+++ b/spark-connector-examples/src/main/scala/io/pravega/example/spark/StreamPravegaToPravega.scala
@@ -20,13 +20,14 @@ object StreamPravegaToPravega {
       .getOrCreate()
 
     val scope = sys.env.getOrElse("PRAVEGA_SCOPE", "examples")
+    val allowCreateScope = !sys.env.contains("PROJECT_NAME")
     val controller = sys.env.getOrElse("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
     val checkpointLocation = sys.env.getOrElse("CHECKPOINT_DIR", "/tmp/spark-checkpoints-StreamPravegaToPravega")
 
     spark
       .readStream
       .format("pravega")
-      .option("allow_create_scope", "false")
+      .option("allow_create_scope", allowCreateScope)
       .option("controller", controller)
       .option("scope", scope)
       .option("stream", "streamprocessing1")

--- a/spark-connector-examples/src/main/scala/io/pravega/example/spark/StreamPravegaToPravega.scala
+++ b/spark-connector-examples/src/main/scala/io/pravega/example/spark/StreamPravegaToPravega.scala
@@ -20,11 +20,13 @@ object StreamPravegaToPravega {
       .getOrCreate()
 
     val scope = sys.env.getOrElse("PRAVEGA_SCOPE", "examples")
-    val controller = sys.env.getOrElse("PRAVEGA_CONTROLLER", "tcp://127.0.0.1:9090")
+    val controller = sys.env.getOrElse("PRAVEGA_CONTROLLER_URI", "tcp://127.0.0.1:9090")
+    val checkpointLocation = sys.env.getOrElse("CHECKPOINT_DIR", "/tmp/spark-checkpoints-StreamPravegaToPravega")
 
     spark
       .readStream
       .format("pravega")
+      .option("allow_create_scope", "false")
       .option("controller", controller)
       .option("scope", scope)
       .option("stream", "streamprocessing1")
@@ -36,10 +38,11 @@ object StreamPravegaToPravega {
       .trigger(Trigger.ProcessingTime(3000))
       .outputMode("append")
       .format("pravega")
+      .option("allow_create_scope", "false")
       .option("controller", controller)
       .option("scope", scope)
       .option("stream", "streamprocessing2")
-      .option("checkpointLocation", "/tmp/spark-checkpoints-StreamPravegaToPravega")
+      .option("checkpointLocation", checkpointLocation)
       .start()
       .awaitTermination()
   }


### PR DESCRIPTION
These changes allow the Spark Scala examples to run on SDP. The examples continue to work on Pravega OSS.