### PR TITLE
[issue-288] Update Flink samples to Flink 1.12 and fix deprecated

### DIFF
--- a/flink-connector-examples/doc/flink-wordcount/README.md
+++ b/flink-connector-examples/doc/flink-wordcount/README.md
@@ -65,14 +65,14 @@ Suppose Flink is installed at /usr/share/flink. Before starting Flink you will n
 taskmanager.numberOfTaskSlots: 4
 ```
 
-By default, Flink job manager runs on port 6123.
+By default, Flink job manager rest API runs on port 8081 to receive job submission, and it is configurable via `rest.port`.
 
 Point your browser to `http://<your_flink_host>:8081` to make sure Flink is running; then click "Running Jobs"
 
 ### Start WordCountWriter
 ```
 $ cd flink-examples/build/install/pravega-flink-examples
-$ flink run -m localhost:6123 -c io.pravega.example.flink.wordcount.WordCountWriter lib/pravega-flink-examples-0.2.0-SNAPSHOT-all.jar --host localhost --port 9999 --controller tcp://localhost:9090
+$ flink run -m localhost:8081 -c io.pravega.example.flink.wordcount.WordCountWriter lib/pravega-flink-examples-0.2.0-SNAPSHOT-all.jar --host localhost --port 9999 --controller tcp://localhost:9090
 ```
 The `WordCountWriter` job should show up on the Flink UI as a running job.
 
@@ -80,7 +80,7 @@ The `WordCountWriter` job should show up on the Flink UI as a running job.
 In a different window:
 ```
 $ cd flink-examples/build/install/pravega-flink-examples
-$ flink run -m localhost:6123 -c io.pravega.example.flink.wordcount.WordCountReader lib/pravega-flink-examples-0.2.0-SNAPSHOT-all.jar --controller tcp://localhost:9090
+$ flink run -m localhost:8081 -c io.pravega.example.flink.wordcount.WordCountReader lib/pravega-flink-examples-0.2.0-SNAPSHOT-all.jar --controller tcp://localhost:9090
 ```
 The `WordCountReader` job should show up on the Flink UI as a running job.
 

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/process/ExactlyOnceChecker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/process/ExactlyOnceChecker.java
@@ -93,6 +93,8 @@ public class ExactlyOnceChecker {
                         System.out.println("No duplicate found. EXACTLY_ONCE!");
                     } else {
                         System.out.println("Found duplicates");
+                        checker.clear();
+                        duplicates.clear();
                     }
                     System.out.println("============== Checker ends  ===============\n");
                 }

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/source/ThrottledIntegerEventProducer.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/source/ThrottledIntegerEventProducer.java
@@ -13,7 +13,7 @@ package io.pravega.example.flink.primer.source;
 
 
 import io.pravega.example.flink.primer.datatype.IntegerEvent;
-import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.util.Preconditions;

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/source/ThrottledIntegerEventProducer.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/source/ThrottledIntegerEventProducer.java
@@ -14,19 +14,21 @@ package io.pravega.example.flink.primer.source;
 
 import io.pravega.example.flink.primer.datatype.IntegerEvent;
 import org.apache.flink.api.common.state.CheckpointListener;
-import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializableObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.List;
-
 public class ThrottledIntegerEventProducer
         extends RichParallelSourceFunction<IntegerEvent>
-        implements ListCheckpointed<Long>, CheckpointListener {
+        implements CheckpointedFunction, CheckpointListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(ThrottledIntegerEventProducer.class);
 
@@ -52,7 +54,7 @@ public class ThrottledIntegerEventProducer
     private long lastCheckpointConfirmed;
 
     // The position of last checkpoint
-    private long checkpointPosition = -1;
+    private ListState<Long> checkpointPosition = null;
 
     // Set to true after restore
     private boolean restored = false;
@@ -164,29 +166,34 @@ public class ThrottledIntegerEventProducer
     }
 
     @Override
-    public List<Long> snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
-        this.lastCheckpointTriggered = checkpointId;
-        this.checkpointPosition = this.currentPosition;
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        this.checkpointPosition.clear();
+        this.checkpointPosition.add(this.currentPosition);
+        this.lastCheckpointTriggered = context.getCheckpointId();
         System.out.println("Start checkpointing at position " + this.currentPosition);
-        return Collections.singletonList(this.currentPosition);
     }
 
     @Override
-    public void restoreState(List<Long> state) throws Exception {
-        this.currentPosition = state.get(0);
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        this.checkpointPosition = context.getOperatorStateStore().getListState(new ListStateDescriptor<>(
+                "state",
+                LongSerializer.INSTANCE));
 
-        // at least one checkpoint must have happened so far
-        this.lastCheckpointTriggered = 1L;
-        this.lastCheckpointConfirmed = 1L;
-        this.restored = true;
-        System.out.println("Restore from checkpoint at position " + this.currentPosition);
+        if (context.isRestored()) {
+            this.currentPosition = checkpointPosition.get().iterator().next();
+            // at least one checkpoint must have happened so far
+            this.lastCheckpointTriggered = 1L;
+            this.lastCheckpointConfirmed = 1L;
+            this.restored = true;
+            System.out.println("Restore from checkpoint at position " + this.currentPosition);
+        }
     }
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
 
         synchronized (blocker) {
-            if (checkpointPosition > -1) {
+            if (checkpointPosition.get().iterator().next() > -1) {
                 // confirm only after a "real" checkpoint, i.e., position is greater than -1.
                 this.lastCheckpointConfirmed = checkpointId;
                 System.out.println("Complete checkpointing at position " + this.checkpointPosition);
@@ -194,5 +201,4 @@ public class ThrottledIntegerEventProducer
             blocker.notifyAll();
         }
     }
-
 }

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/util/FailingMapper.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/primer/util/FailingMapper.java
@@ -11,7 +11,9 @@
 package io.pravega.example.flink.primer.util;
 
 import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 
 import java.util.List;
 
@@ -24,7 +26,7 @@ import java.util.List;
  * where a failure is never triggered (for example because of a too high value for
  * the number of elements to pass before failing).
  */
-public class FailingMapper<T> implements MapFunction<T, T>, ListCheckpointed<Integer> {
+public class FailingMapper<T> implements MapFunction<T, T>, CheckpointedFunction {
 
     /**
      * The number of elements to wait for, before failing
@@ -56,18 +58,20 @@ public class FailingMapper<T> implements MapFunction<T, T>, ListCheckpointed<Int
     @Override
     public String toString() {
         return "FAILING MAPPER: elementCount = " + elementCount + "," +
-                "failedAtElemtn = " + failAtElement + "," +
+                "failedAtElement = " + failAtElement + "," +
                 "restored = " + restored;
     }
 
     @Override
-    public void restoreState(List<Integer> list) throws Exception {
-        restored = true;
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        // do nothing
     }
 
     @Override
-    public List<Integer> snapshotState(long l, long l1) throws Exception {
-        return null;
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        if (context.isRestored()) {
+            restored = true;
+        }
     }
 
     public static class IntentionalException extends Exception {

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/streamcuts/process/StreamBookmarker.java
@@ -100,7 +100,7 @@ public class StreamBookmarker {
         // Bookmark those sections of the stream with values < 0 and write the output (StreamCuts).
         DataStreamSink<SensorStreamSlice> dataStreamSink = env.addSource(reader)
                                                               .setParallelism(Constants.PARALLELISM)
-                                                              .keyBy(0)
+                                                              .keyBy(t -> t.f0)
                                                               .process((KeyedProcessFunction) new Bookmarker(pravegaControllerURI))
                                                               .addSink(writer);
 

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/watermark/EventTimeAverage.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/watermark/EventTimeAverage.java
@@ -22,10 +22,10 @@ import io.pravega.example.flink.Utils;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -67,8 +67,6 @@ public class EventTimeAverage {
         // initialize the Flink execution environment
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        // Use event time characteristic
-        env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
         // Set the auto watermark interval to 2 seconds
         env.getConfig().setAutoWatermarkInterval(2000);
 
@@ -92,7 +90,7 @@ public class EventTimeAverage {
         // Calculate the average of each sensor in a 10 second period upon event-time clock.
         DataStream<SensorData> avgStream = dataStream
                 .keyBy(SensorData::getSensorId)
-                .timeWindow(Time.seconds(windowLength))
+                .window(TumblingEventTimeWindows.of(Time.seconds(windowLength)))
                 .aggregate(new WindowAverage(), new WindowProcess())
                 .uid("Count Event-time Average");
 

--- a/flink-connector-examples/src/main/java/io/pravega/example/flink/wordcount/WordCountReader.java
+++ b/flink-connector-examples/src/main/java/io/pravega/example/flink/wordcount/WordCountReader.java
@@ -19,6 +19,7 @@ import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
@@ -73,8 +74,8 @@ public class WordCountReader {
         // count each word over a 10 second time period
         DataStream<WordCount> dataStream = env.addSource(source).name("Pravega Stream")
                 .flatMap(new WordCountReader.Splitter())
-                .keyBy("word")
-                .timeWindow(Time.seconds(10))
+                .keyBy(WordCount::getWord)
+                .window(TumblingProcessingTimeWindows.of(Time.seconds(10)))
                 .sum("count");
 
         // create an output sink to print to stdout for verification

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,9 @@ pravegaKeycloakVersion=0.9.0
 samplesVersion=0.10.0-SNAPSHOT
 
 ### Flink-connector dependencies
-flinkConnectorVersion=0.9.0
-flinkVersion=1.11.2
-flinkMajorMinorVersion=1.11
+flinkConnectorVersion=0.10.0-259.4f79578-SNAPSHOT
+flinkVersion=1.12.4
+flinkMajorMinorVersion=1.12
 flinkScalaVersion=2.12
 
 ### hadoop connector dependencies

--- a/hadoop-connector-examples/build.gradle
+++ b/hadoop-connector-examples/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     compile     "io.pravega:pravega-keycloak-client:${pravegaKeycloakVersion}"
     compileOnly "org.apache.hadoop:hadoop-common:${hadoopVersion}"
     compileOnly "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}"
-    compileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
 }
 
 shadowJar {

--- a/scenarios/anomaly-detection/src/main/java/io/pravega/anomalydetection/event/pipeline/PravegaAnomalyDetectionProcessor.java
+++ b/scenarios/anomaly-detection/src/main/java/io/pravega/anomalydetection/event/pipeline/PravegaAnomalyDetectionProcessor.java
@@ -19,13 +19,12 @@ import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
 import io.pravega.shaded.com.google.gson.Gson;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.streaming.api.CheckpointingMode;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
@@ -33,8 +32,10 @@ import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
 import org.apache.flink.streaming.connectors.elasticsearch5.ElasticsearchSink;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -62,7 +63,6 @@ public class PravegaAnomalyDetectionProcessor extends AbstractPipeline {
 
 		// Configure the Flink job environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(appConfiguration.getPipeline().getParallelism());
 		if(!appConfiguration.getPipeline().isDisableCheckpoint()) {
 			long checkpointInterval = appConfiguration.getPipeline().getCheckpointIntervalInMilliSec();
@@ -77,7 +77,7 @@ public class PravegaAnomalyDetectionProcessor extends AbstractPipeline {
 
 		// 2. detect anomalies in event sequences
 		DataStream<Event.Alert> anomalies = events
-				.keyBy("sourceAddress")
+				.keyBy(Event::getSourceAddress)
 				.flatMap(new EventStateMachineMapper())
 				.name("AnomalyDetector");
 		anomalies.print();
@@ -85,12 +85,14 @@ public class PravegaAnomalyDetectionProcessor extends AbstractPipeline {
 		// 3. aggregate the alerts by network over time
 		long maxOutOfOrderness = appConfiguration.getPipeline().getWatermarkOffsetInSec();
 		DataStream<Event.Alert> timestampedAnomalies = anomalies
-				.assignTimestampsAndWatermarks(new EventTimeExtractor(Time.seconds(maxOutOfOrderness)))
+				.assignTimestampsAndWatermarks(WatermarkStrategy
+						.<Event.Alert>forBoundedOutOfOrderness(Duration.ofSeconds(maxOutOfOrderness))
+						.withTimestampAssigner((event, timestamp) -> event.getEvent().getEventTime().toEpochMilli()))
 				.name("TimeExtractor");
 
 		long windowIntervalInSeconds = appConfiguration.getPipeline().getWindowIntervalInSeconds();
 		DataStream<Result> aggregate = timestampedAnomalies
-				.keyBy("networkId")
+				.keyBy(Event.Alert::getNetworkId)
 				.window(TumblingEventTimeWindows.of(Time.seconds(windowIntervalInSeconds)))
 				.aggregate(new AggregateAlertsToResult())
 				.name("Aggregate");
@@ -104,17 +106,6 @@ public class PravegaAnomalyDetectionProcessor extends AbstractPipeline {
 
 		// Execute the program in the Flink environment
 		env.execute(appConfiguration.getName());
-	}
-
-	public static class EventTimeExtractor extends BoundedOutOfOrdernessTimestampExtractor<Event.Alert> {
-
-		public EventTimeExtractor(Time time) { super(time); }
-
-		@Override
-		public long extractTimestamp(Event.Alert element) {
-			long timestamp = element.getEvent().getEventTime().toEpochMilli();
-			return timestamp;
-		}
 	}
 
 	public static class AggregateAlertsToResult implements AggregateFunction<Event.Alert, Result, Result> {
@@ -206,7 +197,7 @@ public class PravegaAnomalyDetectionProcessor extends AbstractPipeline {
 					.index(index)
 					.type(type)
 					.id(element.getNetworkId())
-					.source(resultAsJson);
+					.source(resultAsJson, XContentFactory.xContentType(resultAsJson));
 		}
 	}
 }

--- a/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/AbstractHandler.java
+++ b/scenarios/pravega-flink-connector-sql-samples/src/main/java/io/pravega/connectors/nytaxi/AbstractHandler.java
@@ -18,7 +18,6 @@ import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.nytaxi.common.Helper;
 import lombok.Data;
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 import java.net.URI;
@@ -68,7 +67,6 @@ public abstract class AbstractHandler {
 
     public StreamExecutionEnvironment getStreamExecutionEnvironment() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
         env.setParallelism(1);
         return env;
     }

--- a/scenarios/turbine-heat-processor/src/main/dist/bin/run-example
+++ b/scenarios/turbine-heat-processor/src/main/dist/bin/run-example
@@ -9,4 +9,4 @@
 #
 #!/usr/bin/env bash
 
-flink run -c io.pravega.turbineheatprocessor.TurbineHeatProcessor lib/pravega-flink-scenario-turbineheatprocessor-0.4.0-SNAPSHOT-all.jar $*
+flink run -c io.pravega.turbineheatprocessor.TurbineHeatProcessor lib/pravega-flink-scenario-turbineheatprocessor-0.10.0-SNAPSHOT-all.jar $*

--- a/scenarios/turbine-heat-processor/src/main/java/io/pravega/turbineheatprocessor/TurbineHeatProcessor.java
+++ b/scenarios/turbine-heat-processor/src/main/java/io/pravega/turbineheatprocessor/TurbineHeatProcessor.java
@@ -17,17 +17,18 @@ import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.PravegaConfig;
 import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
+
+import java.time.Duration;
 
 public class TurbineHeatProcessor {
     public static void main(String[] args) throws Exception {
@@ -45,7 +46,6 @@ public class TurbineHeatProcessor {
 
         // set up the streaming execution environment
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
         env.setParallelism(1); // required since on a multi core CPU machine, the watermark is not advancing due to idle sources and causing window not to trigger
 
         // 1. read and decode the sensor events from a Pravega stream
@@ -57,17 +57,13 @@ public class TurbineHeatProcessor {
         DataStream<SensorEvent> events = env.addSource(source, "input").map(new SensorMapper()).name("events");
 
         // 2. extract timestamp information to support 'event-time' processing
-        SingleOutputStreamOperator<SensorEvent> timestamped = events.assignTimestampsAndWatermarks(
-                new BoundedOutOfOrdernessTimestampExtractor<SensorEvent>(Time.seconds(10)) {
-            @Override
-            public long extractTimestamp(SensorEvent element) {
-                return element.getTimestamp();
-            }
-        });
+        SingleOutputStreamOperator<SensorEvent> timestamped = events.assignTimestampsAndWatermarks(WatermarkStrategy
+                .<SensorEvent>forBoundedOutOfOrderness(Duration.ofSeconds(10))
+                .withTimestampAssigner((event, timestamp) -> event.getTimestamp()));
 
         // 3. summarize the temperature data for each sensor
         SingleOutputStreamOperator<SensorAggregate> summaries = timestamped
-                .keyBy("sensorId")
+                .keyBy(SensorEvent::getSensorId)
                 .window(TumblingEventTimeWindows.of(Time.days(1), Time.hours(8)))
                 .aggregate(new SensorAggregator()).name("summaries");
 

--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -157,7 +157,7 @@ public class TurbineHeatSensor {
 
         options.addOption("help", false, "Help message");
 
-        CommandLineParser parser = new BasicParser();
+        CommandLineParser parser = new DefaultParser();
         try {
 
             CommandLine commandline = parser.parse(options, args);


### PR DESCRIPTION
This PR has upgraded the Flink version to 1.12 and updated some deprecated/removed usage including
- [FLINK-6258](https://issues.apache.org/jira/browse/FLINK-6258) `ListCheckpointed`
- [FLINK-17074](https://issues.apache.org/jira/browse/FLINK-17074) `keyBy` with a string and number parameter
- [FLINK-19317](https://issues.apache.org/jira/browse/FLINK-19317) Make `EventTime` the default `TimeCharacteristic` + `timeWindow`
- [FLINK-17661](https://issues.apache.org/jira/browse/FLINK-17661) Deprecate old Watermark Assigner API
- [FLINK-19035](https://issues.apache.org/jira/browse/FLINK-19035) `DataStream#fold()`

### Testing

Flink Exactly once app checker result:
```
// exactly once
============== Checker starts ===============
No duplicate found. EXACTLY_ONCE!
============== Checker ends  ===============

// at-least once
============== Checker starts ===============
Duplicate event: 20
Duplicate event: 21
Duplicate event: 23
Found duplicates
============== Checker ends  ===============
```