### PR TITLE
[Issue-293] Update dev branch to use flink-connectors 0.10.0 snapshot builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,6 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *   
  */
- buildscript {
-    repositories {
-        jcenter()
-    }
-}
 
 plugins {
     id 'org.hidetake.ssh' version '2.8.0'
@@ -35,7 +30,13 @@ subprojects {
     }
     repositories {
         mavenLocal()
-        jcenter()
+        maven {
+            url "https://maven.pkg.github.com/pravega/flink-connectors"
+            credentials {
+                username = "pravega-public"
+                password = "\u0067\u0068\u0070\u005F\u0048\u0034\u0046\u0079\u0047\u005A\u0031\u006B\u0056\u0030\u0051\u0070\u006B\u0079\u0058\u006D\u0035\u0063\u0034\u0055\u0033\u006E\u0032\u0065\u0078\u0039\u0032\u0046\u006E\u0071\u0033\u0053\u0046\u0076\u005A\u0049"
+            }
+        }
         mavenCentral()
         maven {
             url "https://repository.apache.org/snapshots"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ pravegaKeycloakVersion=0.9.0
 samplesVersion=0.10.0-SNAPSHOT
 
 ### Flink-connector dependencies
-flinkConnectorVersion=0.10.0-259.4f79578-SNAPSHOT
+flinkConnectorVersion=0.10.0-264.c00d735-SNAPSHOT
 flinkVersion=1.12.4
 flinkMajorMinorVersion=1.12
 flinkScalaVersion=2.12


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**
Changes the destination for snapshot artifacts from JCenter to GitHub Packages Registry.

**Purpose of the change**
Fixes #293 

**What the code does**
- Snapshot repositories is updated to pull from GPR
- Removes jcenter()/jfrog references from build scripts

**How to verify it**
Once the PR is merged the next build on dev branch should pull the latest flink-connectors from the updated GPR.

**Known Limitations**

- Using snapshot packages in other repository is not allowed without the authentication.

Limitation can be handled in the following way:

- Create import token in pravega repository with read:packages scope. This can be shared with others
- In the other repository add the following to repositories list

```
maven {
           url "https://maven.pkg.github.com/pravega/flink-connectors"
           credentials {
             username = "pravega"
             password = IMPORT_TOKEN // this is token created above 
           }
       }
```