### PR TITLE
[Issue-309] Use UTF8StringSerializer instead of JavaSerializer for better performance

### DIFF
--- a/pravega-client-examples/src/main/java/io/pravega/example/consolerw/ConsoleReader.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/consolerw/ConsoleReader.java
@@ -11,10 +11,30 @@
 package io.pravega.example.consolerw;
 
 import io.pravega.client.ClientConfig;
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
@@ -33,25 +53,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.Cleanup;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.admin.StreamManager;
-import io.pravega.client.stream.EventRead;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.ReaderConfig;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ReinitializationRequiredException;
-import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.JavaSerializer;
 
 /**
  * This class implements a simple console interface with the client for demonstration purposes. Specifically, this class
@@ -231,7 +232,7 @@ public class ConsoleReader implements Closeable {
         try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope,
                 ClientConfig.builder().controllerURI(controllerURI).build());
              EventStreamReader<String> reader = clientFactory.createReader("streamcut-reader",
-                     readerGroup, new JavaSerializer<>(), ReaderConfig.builder().build())) {
+                     readerGroup, new UTF8StringSerializer(), ReaderConfig.builder().build())) {
 
             // The reader(s) will only read and display events within the StreamCut boundaries defined.
             output("StreamCuts: Bounded processing example in stream %s/%s%n", scope, streamName);
@@ -363,7 +364,7 @@ class BackgroundReader implements Closeable, Runnable {
             ReaderGroup readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
 
             EventStreamReader<String> reader = clientFactory.createReader("backgroundReader", readerGroupName,
-                    new JavaSerializer<>(), ReaderConfig.builder().build());
+                    new UTF8StringSerializer(), ReaderConfig.builder().build());
             EventRead<String> event;
 
             // Start main loop to continuously read and display events written to the scope/stream.

--- a/pravega-client-examples/src/main/java/io/pravega/example/consolerw/ConsoleWriter.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/consolerw/ConsoleWriter.java
@@ -10,6 +10,25 @@
  */
 package io.pravega.example.consolerw;
 
+import io.pravega.client.ClientConfig;
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.Transaction;
+import io.pravega.client.stream.Transaction.Status;
+import io.pravega.client.stream.TransactionalEventStreamWriter;
+import io.pravega.client.stream.TxnFailedException;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -20,20 +39,6 @@ import java.util.List;
 import java.util.Scanner;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
-import io.pravega.client.ClientConfig;
-import io.pravega.client.stream.*;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-
-import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.admin.StreamManager;
-import io.pravega.client.stream.Transaction.Status;
-import io.pravega.client.stream.impl.JavaSerializer;
 
 /**
  * Uses the Console to present a CLI to write events to a Stream or a Transaction.
@@ -409,8 +414,8 @@ public class ConsoleWriter implements AutoCloseable {
         streamManager.createStream(scope, streamName, streamConfig);
         
         try(EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, ClientConfig.builder().controllerURI(controllerURI).build());
-            EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new JavaSerializer<>(), EventWriterConfig.builder().build());
-            TransactionalEventStreamWriter<String> writerTxn = clientFactory.createTransactionalEventWriter(streamName, new JavaSerializer<>(),
+            EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, new UTF8StringSerializer(), EventWriterConfig.builder().build());
+            TransactionalEventStreamWriter<String> writerTxn = clientFactory.createTransactionalEventWriter(streamName, new UTF8StringSerializer(),
                     EventWriterConfig.builder().build());
             ConsoleWriter cw = new ConsoleWriter(scope, streamName, writer, writerTxn)){
             cw.run();

--- a/pravega-client-examples/src/main/java/io/pravega/example/gettingstarted/HelloWorldReader.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/gettingstarted/HelloWorldReader.java
@@ -10,18 +10,7 @@
  */
 package io.pravega.example.gettingstarted;
 
-import java.net.URI;
-import java.util.UUID;
-
 import io.pravega.client.ClientConfig;
-import io.pravega.client.stream.Stream;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-
 import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
@@ -31,8 +20,18 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import java.net.URI;
+import java.util.UUID;
 
 /**
  * A simple example app that uses a Pravega Reader to read from a given scope and stream.
@@ -71,7 +70,7 @@ public class HelloWorldReader {
                 ClientConfig.builder().controllerURI(controllerURI).build());
              EventStreamReader<String> reader = clientFactory.createReader("reader",
                                                                            readerGroup,
-                                                                           new JavaSerializer<String>(),
+                                                                           new UTF8StringSerializer(),
                                                                            ReaderConfig.builder().build())) {
             System.out.format("Reading all the events from %s/%s%n", scope, streamName);
             EventRead<String> event = null;

--- a/pravega-client-examples/src/main/java/io/pravega/example/gettingstarted/HelloWorldWriter.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/gettingstarted/HelloWorldWriter.java
@@ -10,10 +10,14 @@
  */
 package io.pravega.example.gettingstarted;
 
-import java.net.URI;
-import java.util.concurrent.CompletableFuture;
-
 import io.pravega.client.ClientConfig;
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -21,13 +25,8 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.admin.StreamManager;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.JavaSerializer;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A simple example app that uses a Pravega Writer to write to a given scope and stream.
@@ -56,9 +55,9 @@ public class HelloWorldWriter {
         try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope,
                 ClientConfig.builder().controllerURI(controllerURI).build());
              EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
-                                                                                 new JavaSerializer<String>(),
-                                                                                 EventWriterConfig.builder().build())) {
-            
+                     new UTF8StringSerializer(),
+                     EventWriterConfig.builder().build())) {
+
             System.out.format("Writing message: '%s' with routing-key: '%s' to stream '%s / %s'%n",
                     message, routingKey, scope, streamName);
             final CompletableFuture writeFuture = writer.writeEvent(routingKey, message);

--- a/pravega-client-examples/src/main/java/io/pravega/example/secure/SecureBatchReader.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/secure/SecureBatchReader.java
@@ -10,36 +10,25 @@
  */
 package io.pravega.example.secure;
 
-import com.google.common.collect.Lists;
 import io.pravega.client.BatchClientFactory;
 import io.pravega.client.ClientConfig;
-import io.pravega.client.SynchronizerClientFactory;
-import io.pravega.client.admin.StreamManager;
 import io.pravega.client.batch.SegmentIterator;
 import io.pravega.client.batch.SegmentRange;
-import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.DefaultCredentials;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.common.concurrent.Futures;
-import java.net.URI;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.Random;
-import java.util.UUID;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static io.pravega.common.concurrent.ExecutorServiceHelpers.newScheduledThreadPool;
 
@@ -192,7 +181,7 @@ public class SecureBatchReader implements AutoCloseable {
     }
 
     private int readFromSegments(BatchClientFactory batchClient, List<SegmentRange> segments) throws Exception {
-        JavaSerializer<String> serializer = new JavaSerializer<>();
+        UTF8StringSerializer serializer = new UTF8StringSerializer();
         int count = segments
                 .stream()
                 .mapToInt(segment -> {

--- a/pravega-client-examples/src/main/java/io/pravega/example/secure/SecureReader.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/secure/SecureReader.java
@@ -19,8 +19,7 @@ import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.impl.DefaultCredentials;
-import io.pravega.client.stream.impl.JavaSerializer;
-
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -126,7 +125,7 @@ public class SecureReader {
             System.out.println("Done creating a client factory with the specified scope and client config.");
 
             reader = clientFactory.createReader("readerId", readerGroupName,
-                    new JavaSerializer<>(), ReaderConfig.builder().build());
+                    new UTF8StringSerializer(), ReaderConfig.builder().build());
             System.out.println("Done creating a reader.");
 
             String readMessage = reader.readNextEvent(2000).getEvent();

--- a/pravega-client-examples/src/main/java/io/pravega/example/secure/SecureWriter.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/secure/SecureWriter.java
@@ -18,8 +18,7 @@ import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.DefaultCredentials;
-import io.pravega.client.stream.impl.JavaSerializer;
-
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -128,7 +127,7 @@ public class SecureWriter {
             clientFactory = EventStreamClientFactory.withScope(this.scope, clientConfig);
             System.out.println("Done creating a client factory with the specified scope and client config.");
 
-            writer = clientFactory.createEventWriter(this.stream, new JavaSerializer<String>(),
+            writer = clientFactory.createEventWriter(this.stream, new UTF8StringSerializer(),
                     EventWriterConfig.builder().build());
             System.out.println("Done creating a writer.");
 

--- a/pravega-client-examples/src/main/java/io/pravega/example/streamcuts/StreamCutsExample.java
+++ b/pravega-client-examples/src/main/java/io/pravega/example/streamcuts/StreamCutsExample.java
@@ -30,7 +30,10 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
-import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.Closeable;
 import java.net.URI;
 import java.util.AbstractMap.SimpleEntry;
@@ -42,8 +45,6 @@ import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.function.Consumer;
-import lombok.Cleanup;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class StreamCutsExample implements Closeable {
@@ -101,7 +102,7 @@ public class StreamCutsExample implements Closeable {
             ReaderGroup readerGroup = manager.getReaderGroup(readerGroupName);
             @Cleanup
             EventStreamReader<String> reader = clientFactory.createReader(randomId, readerGroup.getGroupName(),
-                    new JavaSerializer<>(), ReaderConfig.builder().build());
+                    new UTF8StringSerializer(), ReaderConfig.builder().build());
 
             // Read streams and create the StreamCuts during the read process.
             int eventIndex = 0;
@@ -112,7 +113,7 @@ public class StreamCutsExample implements Closeable {
                     reader.close();
                     streamCuts.add(readerGroup.getStreamCuts().get(Stream.of(scope, streamName)));
                     reader = clientFactory.createReader(randomId, readerGroup.getGroupName(),
-                            new JavaSerializer<>(), ReaderConfig.builder().build());
+                            new UTF8StringSerializer(), ReaderConfig.builder().build());
                 }
 
                 event = reader.readNextEvent(1000);
@@ -153,7 +154,7 @@ public class StreamCutsExample implements Closeable {
             manager.createReaderGroup(readerGroupName, config);
             @Cleanup
             EventStreamReader<String> reader = clientFactory.createReader(randomId, readerGroupName,
-                    new JavaSerializer<>(), ReaderConfig.builder().build());
+                    new UTF8StringSerializer(), ReaderConfig.builder().build());
 
             // Write dummy events that identify each Stream.
             EventRead<String> event;
@@ -199,7 +200,7 @@ public class StreamCutsExample implements Closeable {
 
                 // We basically sum up all the values of events within the ranges.
                 for (SegmentRange range: ranges) {
-                    List<String> eventData = Lists.newArrayList(batchClient.readSegment(range, new JavaSerializer<>()));
+                    List<String> eventData = Lists.newArrayList(batchClient.readSegment(range, new UTF8StringSerializer()));
                     totalSumValuesInDay += eventData.stream().map(s -> s.split(eventSeparator)[2]).mapToInt(Integer::valueOf).sum();
                 }
             }
@@ -241,7 +242,7 @@ public class StreamCutsExample implements Closeable {
             try (EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope,
                     ClientConfig.builder().controllerURI(controllerURI).build());
                  EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
-                         new JavaSerializer<>(), EventWriterConfig.builder().build())) {
+                         new UTF8StringSerializer(), EventWriterConfig.builder().build())) {
 
                 // Write data to the streams according to our preferences
                 final SimpleEntry<EventStreamWriter<String>, String> writerAndStreamName = new SimpleEntry<>(writer, streamName);

--- a/scenarios/turbine-heat-processor/README.md
+++ b/scenarios/turbine-heat-processor/README.md
@@ -24,18 +24,16 @@ Alternately, run the sample from the Flink UI.
 
 ## Outputs
 The application outputs the daily summary as a comma-separated values (CSV) file, one line per sensor per day. The data is
-also emitted to stdout (which may be viewed in the Flink UI). For example:
+also visable in the Flink UI. For example:
 
 ```
 ...
-SensorAggregate(1065600000,12,Illinois,(60.0,100.0))
-SensorAggregate(1065600000,3,Arkansas,(60.0,100.0))
-SensorAggregate(1065600000,7,Delaware,(60.0,100.0))
-SensorAggregate(1065600000,15,Kansas,(40.0,80.0))
-SensorAggregate(1152000000,3,Arkansas,(60.0,100.0))
-SensorAggregate(1152000000,12,Illinois,(60.0,100.0))
-SensorAggregate(1152000000,15,Kansas,(40.0,80.0))
-SensorAggregate(1152000000,7,Delaware,(60.0,100.0))
+SensorAggregate{startTime=28800000, sensorId=2, location='Arizona', tempMin=50.0, tempMax=90.0}
+SensorAggregate{startTime=28800000, sensorId=18, location='Maine', tempMin=30.0, tempMax=70.0}
+SensorAggregate{startTime=28800000, sensorId=10, location='Hawaii', tempMin=40.0, tempMax=80.0}
+SensorAggregate{startTime=28800000, sensorId=3, location='Arkansas', tempMin=60.0, tempMax=100.0}
+SensorAggregate{startTime=28800000, sensorId=0, location='Alabama', tempMin=50.0, tempMax=90.0}
+SensorAggregate{startTime=28800000, sensorId=17, location='Louisiana', tempMin=70.0, tempMax=110.0}
+SensorAggregate{startTime=28800000, sensorId=19, location='Maryland', tempMin=60.0, tempMax=100.0}
 ...
 ```
-

--- a/scenarios/turbine-heat-processor/src/main/java/io/pravega/turbineheatprocessor/TurbineHeatProcessor.java
+++ b/scenarios/turbine-heat-processor/src/main/java/io/pravega/turbineheatprocessor/TurbineHeatProcessor.java
@@ -13,13 +13,12 @@ package io.pravega.turbineheatprocessor;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.connectors.flink.FlinkPravegaReader;
 import io.pravega.connectors.flink.PravegaConfig;
-import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -52,7 +51,7 @@ public class TurbineHeatProcessor {
         FlinkPravegaReader<String> source = FlinkPravegaReader.<String>builder()
                 .withPravegaConfig(pravegaConfig)
                 .forStream(stream)
-                .withDeserializationSchema(new PravegaDeserializationSchema<>(String.class, new JavaSerializer<>()))
+                .withDeserializationSchema(new SimpleStringSchema())
                 .build();
         DataStream<SensorEvent> events = env.addSource(source, "input").map(new SensorMapper()).name("events");
 

--- a/scenarios/turbine-heat-processor/src/main/scala/io/pravega/turbineheatprocessor/TurbineHeatProcessorScala.scala
+++ b/scenarios/turbine-heat-processor/src/main/scala/io/pravega/turbineheatprocessor/TurbineHeatProcessorScala.scala
@@ -8,14 +8,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  */
-package io.pravega.turbineheatprocessor;
+package io.pravega.turbineheatprocessor
 
-import io.pravega.client.stream.impl.JavaSerializer
 import io.pravega.client.stream.{ScalingPolicy, StreamConfiguration}
-import io.pravega.connectors.flink.serialization.PravegaDeserializationSchema
 import io.pravega.connectors.flink.{FlinkPravegaReader, PravegaConfig}
 import org.apache.flink.api.common.eventtime.{SerializableTimestampAssigner, WatermarkStrategy}
 import org.apache.flink.api.common.functions.AggregateFunction
+import org.apache.flink.api.common.serialization.SimpleStringSchema
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.core.fs.FileSystem
 import org.apache.flink.streaming.api.scala._
@@ -91,7 +90,7 @@ object TurbineHeatProcessorScala {
     val source = FlinkPravegaReader.builder()
       .withPravegaConfig(pravegaConfig)
       .forStream(stream)
-      .withDeserializationSchema(new PravegaDeserializationSchema(classOf[String], new JavaSerializer[String]()))
+      .withDeserializationSchema(new SimpleStringSchema())
       .build()
 
     val events: DataStream[SensorEvent] = env.addSource(source).name("input").map { line =>

--- a/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
+++ b/scenarios/turbine-heat-sensor/src/main/java/io/pravega/turbineheatsensor/TurbineHeatSensor.java
@@ -15,7 +15,7 @@ import io.pravega.client.EventStreamClientFactory;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.*;
-import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import org.apache.commons.cli.*;
 
 import java.net.URI;
@@ -283,7 +283,7 @@ public class TurbineHeatSensor {
 
     private static class TemperatureSensors implements Runnable {
 
-        final JavaSerializer<String> SERIALIZER = new JavaSerializer<>();
+        final UTF8StringSerializer SERIALIZER = new UTF8StringSerializer();
 
         final EventStreamWriter<String> producer;
         private final TemperatureSensor sensor;
@@ -403,7 +403,7 @@ public class TurbineHeatSensor {
         }
 
         BiFunction<String, String, Future> sendFunction() {
-            return  ( key, data) -> {
+            return (key, data) -> {
                 try {
                     transaction.writeEvent(key, data);
                 } catch (TxnFailedException e) {
@@ -420,7 +420,7 @@ public class TurbineHeatSensor {
      */
     private static class SensorReader implements Runnable {
 
-        private final JavaSerializer<String> SERIALIZER = new JavaSerializer<>();
+        final UTF8StringSerializer SERIALIZER = new UTF8StringSerializer();
         final EventStreamReader<String> reader;
         private int totalEvents;
 


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
The existing JavaSerializer used in the writer and reader of several examples is slow and vulnerable. Use UTF8StringSerializer instead.

**Purpose of the change**
Fixes #309 

**What the code does**
Change JavaSerializer to UTF8StringSerializer in the following examples:
* scenarios\turbineheatsensor
* scenarios\turbineheatprocessor
* pravega-client-examples\gettingstarted
* pravega-client-examples\streamcuts
* pravega-client-examples\consolerw
* pravega-client-examples\secure

**How to verify it**
All examples should behave as before.
