### PR TITLE
Issue 325: Prepare for release 0.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,26 +8,26 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### Pravega dependencies
-pravegaVersion=0.10.1
-pravegaKeycloakVersion=0.10.1
+pravegaVersion=0.11.0
+pravegaKeycloakVersion=0.11.0
 
 ### Pravega-samples output library
-samplesVersion=0.11.0-SNAPSHOT
+samplesVersion=0.11.0
 
 ### Flink-connector dependencies
-flinkConnectorVersion=0.10.1
+flinkConnectorVersion=0.11.0
 flinkVersion=1.12.4
 flinkMajorMinorVersion=1.12
 flinkScalaVersion=2.12
 
 ### schema registry sample dependencies
-schemaRegistryVersion=0.3.0
+schemaRegistryVersion=0.4.0
 commonsCliVersion=1.4
 
 ### Spark connector dependencies
 scalaVersion=2.12.13
 sparkVersion=3.0.1
-sparkConnectorVersion=0.10.1
+sparkConnectorVersion=0.11.0
 
 ### Samples application dependencies
 kryoSerializerVersion=0.45


### PR DESCRIPTION
**Change log description**
Updated samples version to 0.11.0 and all dependency artifact versions to 0.11.0. Updated Schema Registry version to 0.4.0.

**Purpose of the change**
Fixes https://github.com/pravega/pravega-samples/issues/325.

**What the code does**
Updated samples version to 0.11.0 and all dependency artifact versions to 0.11.0. Updated Schema Registry version to 0.4.0.

**How to verify it**
`./gradlew clean installDist` should pass

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>
