### PR TITLE
Issue 343: Prepare for 0.13 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,26 +8,26 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 ### Pravega dependencies
-pravegaVersion=0.13.0-3184.23d8ef6-SNAPSHOT
-pravegaKeycloakVersion=0.12.0
+pravegaVersion=0.13.0
+pravegaKeycloakVersion=0.13.0
 
 ### Pravega-samples output library
-samplesVersion=0.12.0
+samplesVersion=0.13.0
 
 ### Flink-connector dependencies
-flinkConnectorVersion=0.12.0
-flinkVersion=1.13.6
-flinkMajorMinorVersion=1.13
+flinkConnectorVersion=0.13.0
+flinkVersion=1.14.6
+flinkMajorMinorVersion=1.14
 flinkScalaVersion=2.12
 
 ### schema registry sample dependencies
-schemaRegistryVersion=0.5.0
+schemaRegistryVersion=0.6.0
 commonsCliVersion=1.4
 
 ### Spark connector dependencies
 scalaVersion=2.12.13
 sparkVersion=3.0.1
-sparkConnectorVersion=0.12.0
+sparkConnectorVersion=0.13.0
 
 ### Samples application dependencies
 kryoSerializerVersion=0.45

--- a/scenarios/pravega-flink-connector-sql-samples/build.gradle
+++ b/scenarios/pravega-flink-connector-sql-samples/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile "org.apache.flink:flink-table-api-java-bridge_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-clients_${flinkScalaVersion}:${flinkVersion}"
     compile "org.apache.flink:flink-json:${flinkVersion}"
-    compile "org.apache.flink:flink-table-planner-blink_${flinkScalaVersion}:${flinkVersion}"
+    compile "org.apache.flink:flink-table-planner_${flinkScalaVersion}:${flinkVersion}"
 
     compile "ch.qos.logback:logback-classic:1.1.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.8.9"


### PR DESCRIPTION
**Change log description**
Updated samples version to 0.13.0 and all dependency artifact versions to 0.13.0. Updated Schema Registry version to 0.6.0. Changed to Flink Table Planner library in Flink SQL sample.

**Purpose of the change**
Fixes https://github.com/pravega/pravega-samples/issues/343.

**What the code does**
Updated samples version to 0.13.0 and all dependency artifact versions to 0.13.0. Updated Schema Registry version to 0.6.0. Changed to Flink Table Planner library in Flink SQL sample.

**How to verify it**
`./gradlew clean installDist` should pass. Flink SQL sample is working.